### PR TITLE
WhatsApp + Claude auto-reply integration

### DIFF
--- a/playground/whatsapp_claude/test_whatsapp_claude_bot.py
+++ b/playground/whatsapp_claude/test_whatsapp_claude_bot.py
@@ -1,0 +1,429 @@
+"""End-to-end test for WhatsApp + Claude integration.
+
+Runs in three modes:
+    1. Dry-run (default) — tests everything locally, no API calls.
+    2. Claude-only — tests Claude reply generation (needs ANTHROPIC_API_KEY).
+    3. Full — tests the Flask webhook server with simulated Meta payloads.
+
+Usage:
+    # Dry-run (no keys needed)
+    python playground/whatsapp_claude/test_whatsapp_claude_bot.py
+
+    # With Claude replies (needs ANTHROPIC_API_KEY)
+    python playground/whatsapp_claude/test_whatsapp_claude_bot.py --claude
+
+    # Full webhook server test (needs ANTHROPIC_API_KEY)
+    python playground/whatsapp_claude/test_whatsapp_claude_bot.py --full
+
+    # Run the actual bot server (needs all keys)
+    python playground/whatsapp_claude/test_whatsapp_claude_bot.py --serve
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import os
+
+# ── Dry-run tests (no API keys needed) ───────────────────────────────
+
+def test_send_dry_run():
+    """Test sending messages in dry-run mode."""
+    from uutils.whatsapp_uu import send_whatsapp_message, send_whatsapp_template
+
+    print("--- test_send_dry_run ---")
+    send_whatsapp_message("+14155551234", "Hello from dry-run test!", dry_run=True)
+    send_whatsapp_template("+14155551234", "hello_world", dry_run=True)
+    print("PASSED\n")
+
+
+def test_phone_normalization():
+    """Test phone number normalization edge cases."""
+    from uutils.whatsapp_uu import _normalize_phone
+
+    print("--- test_phone_normalization ---")
+    cases = [
+        ("14155551234", "+14155551234"),
+        ("+14155551234", "+14155551234"),
+        ("  +44 20 1234 5678  ", "+442012345678"),
+        ("whatsapp:+14155551234", "+14155551234"),
+        ("+1 (415) 555-1234", "+14155551234"),
+        ("+49.30.1234.5678", "+493012345678"),
+    ]
+    for inp, expected in cases:
+        result = _normalize_phone(inp)
+        assert result == expected, f"_normalize_phone({inp!r}) = {result!r}, expected {expected!r}"
+        print(f"  {inp!r:30s} -> {result!r}")
+    print("PASSED\n")
+
+
+def test_message_extraction():
+    """Test extracting messages from Meta webhook payloads."""
+    from uutils.whatsapp_uu import _extract_messages
+
+    print("--- test_message_extraction ---")
+
+    # Normal text message
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [{
+                        "from": "14155551234",
+                        "id": "wamid.HBgNMTQxNTU1NTEyMzQ",
+                        "type": "text",
+                        "text": {"body": "Hey, can you help me with something?"},
+                        "timestamp": "1713100800",
+                    }],
+                    "contacts": [{
+                        "wa_id": "14155551234",
+                        "profile": {"name": "Alice"},
+                    }],
+                },
+            }],
+        }],
+    }
+    msgs = _extract_messages(payload)
+    assert len(msgs) == 1
+    assert msgs[0]["from_phone"] == "+14155551234"
+    assert msgs[0]["text"] == "Hey, can you help me with something?"
+    assert msgs[0]["contact_name"] == "Alice"
+    print(f"  Extracted: {msgs[0]}")
+
+    # Non-text message should be skipped
+    payload_image = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [{
+                        "from": "14155551234",
+                        "id": "wamid.img123",
+                        "type": "image",
+                        "image": {"id": "img123"},
+                    }],
+                    "contacts": [],
+                },
+            }],
+        }],
+    }
+    msgs = _extract_messages(payload_image)
+    assert len(msgs) == 0
+    print("  Non-text messages correctly skipped")
+
+    # Empty payload
+    msgs = _extract_messages({})
+    assert len(msgs) == 0
+    print("  Empty payload handled")
+
+    # Multiple messages
+    payload_multi = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [
+                        {"from": "14155551234", "id": "wamid.1", "type": "text",
+                         "text": {"body": "First"}},
+                        {"from": "14155559876", "id": "wamid.2", "type": "text",
+                         "text": {"body": "Second"}},
+                    ],
+                    "contacts": [
+                        {"wa_id": "14155551234", "profile": {"name": "Alice"}},
+                        {"wa_id": "14155559876", "profile": {"name": "Bob"}},
+                    ],
+                },
+            }],
+        }],
+    }
+    msgs = _extract_messages(payload_multi)
+    assert len(msgs) == 2
+    assert msgs[0]["contact_name"] == "Alice"
+    assert msgs[1]["contact_name"] == "Bob"
+    print(f"  Multi-message: extracted {len(msgs)} messages")
+
+    print("PASSED\n")
+
+
+def test_bot_conversation_management():
+    """Test the WhatsAppClaudeBot conversation history (no API calls)."""
+    from uutils.whatsapp_uu import WhatsAppClaudeBot
+
+    print("--- test_bot_conversation_management ---")
+
+    bot = WhatsAppClaudeBot(dry_run=True)
+    phone = "+14155551234"
+
+    # Add messages
+    bot.add_message(phone, "user", "Hello!")
+    bot.add_message(phone, "assistant", "Hi there! How can I help?")
+    bot.add_message(phone, "user", "What's the weather like?")
+    history = bot.get_history(phone)
+    assert len(history) == 3
+    assert history[0]["role"] == "user"
+    assert history[2]["content"] == "What's the weather like?"
+    print(f"  History has {len(history)} messages")
+
+    # Separate conversations per phone
+    phone2 = "+442012345678"
+    bot.add_message(phone2, "user", "Different convo")
+    assert len(bot.get_history(phone)) == 3
+    assert len(bot.get_history(phone2)) == 1
+    print("  Per-contact histories are isolated")
+
+    # Clear
+    bot.clear_history(phone)
+    assert len(bot.get_history(phone)) == 0
+    assert len(bot.get_history(phone2)) == 1
+    print("  History cleared correctly")
+
+    # Test trimming (MAX_CONVERSATION_HISTORY)
+    from uutils.whatsapp_uu import MAX_CONVERSATION_HISTORY
+    for i in range(MAX_CONVERSATION_HISTORY + 10):
+        role = "user" if i % 2 == 0 else "assistant"
+        bot.add_message(phone, role, f"Message {i}")
+    assert len(bot.get_history(phone)) <= MAX_CONVERSATION_HISTORY
+    print(f"  History trimmed to <= {MAX_CONVERSATION_HISTORY} messages")
+
+    print("PASSED\n")
+
+
+def test_webhook_app_creation():
+    """Test creating the Flask webhook app (no server start)."""
+    from uutils.whatsapp_uu import WhatsAppClaudeBot, create_whatsapp_webhook_app
+
+    print("--- test_webhook_app_creation ---")
+
+    bot = WhatsAppClaudeBot(dry_run=True)
+    app = create_whatsapp_webhook_app(
+        bot=bot,
+        verify_token="test_token_123",
+        auto_reply=False,  # don't try to call Claude
+    )
+    assert app is not None
+    print("  Flask app created successfully")
+
+    # Test webhook verification endpoint
+    with app.test_client() as client:
+        # Correct token
+        resp = client.get("/webhook?hub.mode=subscribe&hub.verify_token=test_token_123&hub.challenge=challenge_abc")
+        assert resp.status_code == 200
+        assert resp.data == b"challenge_abc"
+        print("  Webhook verification (correct token): 200")
+
+        # Wrong token
+        resp = client.get("/webhook?hub.mode=subscribe&hub.verify_token=wrong&hub.challenge=x")
+        assert resp.status_code == 403
+        print("  Webhook verification (wrong token): 403")
+
+        # Health check
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["status"] == "ok"
+        print(f"  Health check: {data}")
+
+    print("PASSED\n")
+
+
+def test_webhook_message_handling():
+    """Test the webhook POST handler with simulated Meta payloads."""
+    from uutils.whatsapp_uu import WhatsAppClaudeBot, create_whatsapp_webhook_app
+
+    print("--- test_webhook_message_handling ---")
+
+    received_messages = []
+
+    def on_message(phone, text, reply):
+        received_messages.append({"phone": phone, "text": text, "reply": reply})
+
+    bot = WhatsAppClaudeBot(dry_run=True)
+    app = create_whatsapp_webhook_app(
+        bot=bot,
+        verify_token="test_token",
+        auto_reply=False,  # don't call Claude API
+        auto_mark_read=False,  # don't call WhatsApp API
+        on_message=on_message,
+    )
+
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [{
+                        "from": "14155551234",
+                        "id": "wamid.test456",
+                        "type": "text",
+                        "text": {"body": "Can you help me plan a trip?"},
+                        "timestamp": "1713100800",
+                    }],
+                    "contacts": [{
+                        "wa_id": "14155551234",
+                        "profile": {"name": "Alice"},
+                    }],
+                },
+            }],
+        }],
+    }
+
+    with app.test_client() as client:
+        resp = client.post(
+            "/webhook",
+            data=json.dumps(payload),
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        print(f"  Webhook POST response: {resp.status_code}")
+
+    assert len(received_messages) == 1
+    assert received_messages[0]["phone"] == "+14155551234"
+    assert received_messages[0]["text"] == "Can you help me plan a trip?"
+    assert received_messages[0]["reply"] == ""  # auto_reply=False
+    print(f"  Callback received: {received_messages[0]}")
+
+    print("PASSED\n")
+
+
+# ── Claude integration tests (needs ANTHROPIC_API_KEY) ───────────────
+
+def test_claude_reply_generation():
+    """Test actual Claude reply generation (requires ANTHROPIC_API_KEY)."""
+    from uutils.whatsapp_uu import WhatsAppClaudeBot
+
+    print("--- test_claude_reply_generation ---")
+
+    bot = WhatsAppClaudeBot(
+        system_prompt="You are a friendly assistant. Keep replies under 50 words.",
+        model="claude-sonnet-4-20250514",
+        dry_run=True,  # don't send WhatsApp, but do call Claude
+    )
+
+    # First message
+    reply1 = bot.generate_reply("+14155551234", "Hey! What's 2 + 2?")
+    print(f"  User: Hey! What's 2 + 2?")
+    print(f"  Claude: {reply1}")
+    assert len(reply1) > 0
+    assert "4" in reply1 or "four" in reply1.lower()
+
+    # Follow-up (tests conversation context)
+    reply2 = bot.generate_reply("+14155551234", "And what's that times 3?")
+    print(f"  User: And what's that times 3?")
+    print(f"  Claude: {reply2}")
+    assert len(reply2) > 0
+
+    # Different contact (separate history)
+    reply3 = bot.generate_reply("+442012345678", "Hi there!")
+    print(f"  User (+44): Hi there!")
+    print(f"  Claude: {reply3}")
+    assert len(reply3) > 0
+
+    # Verify histories are separate
+    assert len(bot.get_history("+14155551234")) == 4  # 2 user + 2 assistant
+    assert len(bot.get_history("+442012345678")) == 2  # 1 user + 1 assistant
+    print("  Conversation histories correctly isolated")
+
+    print("PASSED\n")
+
+
+def test_full_webhook_with_claude():
+    """Test webhook with actual Claude replies (requires ANTHROPIC_API_KEY)."""
+    from uutils.whatsapp_uu import WhatsAppClaudeBot, create_whatsapp_webhook_app
+
+    print("--- test_full_webhook_with_claude ---")
+
+    replies = []
+
+    def on_message(phone, text, reply):
+        replies.append({"phone": phone, "text": text, "reply": reply})
+
+    bot = WhatsAppClaudeBot(
+        system_prompt="You are a helpful assistant. Keep replies under 30 words.",
+        dry_run=True,  # don't send WhatsApp messages
+    )
+    app = create_whatsapp_webhook_app(
+        bot=bot,
+        verify_token="test",
+        auto_reply=True,  # WILL call Claude
+        auto_mark_read=False,
+        on_message=on_message,
+    )
+
+    payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [{
+                        "from": "14155551234",
+                        "id": "wamid.full_test",
+                        "type": "text",
+                        "text": {"body": "What's the capital of France?"},
+                    }],
+                    "contacts": [{"wa_id": "14155551234", "profile": {"name": "Tester"}}],
+                },
+            }],
+        }],
+    }
+
+    with app.test_client() as client:
+        resp = client.post("/webhook", data=json.dumps(payload), content_type="application/json")
+        assert resp.status_code == 200
+
+    assert len(replies) == 1
+    assert "paris" in replies[0]["reply"].lower()
+    print(f"  Question: What's the capital of France?")
+    print(f"  Reply: {replies[0]['reply']}")
+    print("PASSED\n")
+
+
+# ── Server mode ──────────────────────────────────────────────────────
+
+def run_server():
+    """Start the actual WhatsApp bot server."""
+    from uutils.whatsapp_uu import run_whatsapp_bot
+    run_whatsapp_bot(debug=True)
+
+
+# ── Main ─────────────────────────────────────────────────────────────
+
+def main():
+    parser = argparse.ArgumentParser(description="Test WhatsApp + Claude integration")
+    parser.add_argument("--claude", action="store_true",
+                        help="Run Claude integration tests (needs ANTHROPIC_API_KEY)")
+    parser.add_argument("--full", action="store_true",
+                        help="Run full webhook + Claude tests (needs ANTHROPIC_API_KEY)")
+    parser.add_argument("--serve", action="store_true",
+                        help="Start the actual WhatsApp bot server")
+    args = parser.parse_args()
+
+    if args.serve:
+        run_server()
+        return
+
+    print("=" * 60)
+    print("WhatsApp + Claude Integration Tests")
+    print("=" * 60 + "\n")
+
+    # Always run dry-run tests
+    test_send_dry_run()
+    test_phone_normalization()
+    test_message_extraction()
+    test_bot_conversation_management()
+    test_webhook_app_creation()
+    test_webhook_message_handling()
+
+    if args.claude or args.full:
+        if not os.environ.get("ANTHROPIC_API_KEY") and not os.path.isfile(
+            os.path.expanduser("~/keys/anthropic_api_key.txt")
+        ):
+            print("SKIPPED: Claude tests require ANTHROPIC_API_KEY env var or ~/keys/anthropic_api_key.txt")
+            sys.exit(1)
+        test_claude_reply_generation()
+
+    if args.full:
+        test_full_webhook_with_claude()
+
+    print("=" * 60)
+    print("ALL TESTS PASSED")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/py_src/uutils/whatsapp_uu.py
+++ b/py_src/uutils/whatsapp_uu.py
@@ -1,8 +1,20 @@
-"""WhatsApp messaging — send messages via Meta Business Cloud API or Twilio.
+"""WhatsApp messaging — send/receive messages via Meta Business Cloud API or Twilio,
+with optional Claude-powered auto-replies.
 
-Quick usage:
+Quick usage (send only):
     from uutils.whatsapp_uu import send_whatsapp_message
     send_whatsapp_message("+14155551234", "Hello from uutils!")
+
+Quick usage (Claude auto-reply bot):
+    from uutils.whatsapp_uu import run_whatsapp_bot
+    run_whatsapp_bot()  # starts Flask webhook server on port 5000
+
+Quick usage (programmatic reply without server):
+    from uutils.whatsapp_uu import WhatsAppClaudeBot
+    bot = WhatsAppClaudeBot()
+    reply = bot.generate_reply("+14155551234", "Hey, what's up?")
+    print(reply)
+    # bot.generate_reply_and_send("+14155551234", "Hey, what's up?")  # also sends via WhatsApp
 
 Setup (Meta Business Cloud API — recommended):
     1. Create a Meta Business account: https://business.facebook.com/
@@ -14,10 +26,25 @@ Setup (Meta Business Cloud API — recommended):
            "provider": "meta",
            "access_token": "YOUR_ACCESS_TOKEN",
            "phone_number_id": "YOUR_PHONE_NUMBER_ID",
-           "api_version": "v21.0"
+           "api_version": "v21.0",
+           "verify_token": "YOUR_WEBHOOK_VERIFY_TOKEN"
        }
        JSON
        chmod 600 ~/keys/whatsapp_api_config.json
+
+    5. Set your Anthropic API key (for Claude replies):
+       export ANTHROPIC_API_KEY="sk-ant-..."
+       # or save to: ~/keys/anthropic_api_key.txt
+
+    6. Expose your webhook (for receiving messages):
+       # Option A: ngrok (for local development)
+       ngrok http 5000
+       # Option B: deploy to a server with a public URL
+
+    7. Configure the webhook in Meta Developer Console:
+       - Webhook URL: https://YOUR_DOMAIN/webhook
+       - Verify token: same as verify_token in your config
+       - Subscribe to: messages
 
 Setup (Twilio — alternative):
     1. Create Twilio account: https://www.twilio.com/
@@ -35,20 +62,39 @@ Setup (Twilio — alternative):
 
 Refs:
     - Meta Cloud API: https://developers.facebook.com/docs/whatsapp/cloud-api
+    - Meta Webhooks: https://developers.facebook.com/docs/whatsapp/cloud-api/webhooks
     - Twilio WhatsApp: https://www.twilio.com/docs/whatsapp/api
+    - Anthropic API: https://docs.anthropic.com/en/docs
 """
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import logging
+import os
+import time
+from collections import defaultdict
 from pathlib import Path
+from typing import Any
 
 import requests
 
 log = logging.getLogger(__name__)
 
 DEFAULT_CONFIG_FILE = "~/keys/whatsapp_api_config.json"
+DEFAULT_ANTHROPIC_KEY_FILE = "~/keys/anthropic_api_key.txt"
 _PHONE_SEPARATORS = {" ", "-", "(", ")", "."}
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You are a helpful assistant replying to WhatsApp messages on behalf of the user. "
+    "Keep responses concise and natural — as if texting a friend. "
+    "Use short paragraphs. Avoid markdown formatting (no ** or ## etc.) since this is WhatsApp. "
+    "If the message is casual, be casual. If it's a question, give a clear answer. "
+    "If you're unsure what someone means, ask a brief clarifying question."
+)
+
+MAX_CONVERSATION_HISTORY = 50  # messages per contact to keep in memory
 
 
 def _load_config(config_file: str = "") -> dict:
@@ -246,6 +292,365 @@ def send_whatsapp_template(
     return _send_meta_template(config, to, template_name, language, components)
 
 
+# ── Mark as read ─────────────────────────────────────────────────────
+
+def mark_as_read(message_id: str, config_file: str = "") -> dict | None:
+    """Mark a WhatsApp message as read (Meta Business API only).
+
+    Args:
+        message_id: The wamid of the message to mark as read.
+        config_file: Path to config JSON.
+
+    Returns:
+        API response dict, or None if not using Meta provider.
+    """
+    config = _load_config(config_file)
+    if config["provider"] != "meta":
+        log.debug("mark_as_read only supported with Meta Business API")
+        return None
+    payload = {
+        "messaging_product": "whatsapp",
+        "status": "read",
+        "message_id": message_id,
+    }
+    return _send_meta_request(config, payload)
+
+
+# ── Anthropic / Claude integration ───────────────────────────────────
+
+def _load_anthropic_key() -> str:
+    """Load Anthropic API key from env var or key file."""
+    key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if key:
+        return key.strip()
+    fpath = Path(DEFAULT_ANTHROPIC_KEY_FILE).expanduser()
+    if fpath.is_file():
+        key = fpath.read_text().strip()
+        if key:
+            return key
+    raise ValueError(
+        "No Anthropic API key found. Set ANTHROPIC_API_KEY env var "
+        f"or save your key to {DEFAULT_ANTHROPIC_KEY_FILE}"
+    )
+
+
+class WhatsAppClaudeBot:
+    """Manages Claude-powered replies to WhatsApp conversations.
+
+    Keeps per-contact conversation history in memory and uses the Anthropic API
+    to generate context-aware replies.
+
+    Args:
+        system_prompt: System prompt that shapes Claude's reply style.
+        model: Anthropic model to use.
+        max_tokens: Max tokens per reply.
+        config_file: Path to WhatsApp API config JSON.
+        anthropic_api_key: Explicit key; if empty, reads from env/file.
+        dry_run: If True, don't actually send WhatsApp messages.
+
+    Usage:
+        bot = WhatsAppClaudeBot()
+
+        # Generate a reply without sending
+        reply = bot.generate_reply("+14155551234", "Hey, what's the weather?")
+
+        # Generate and send
+        bot.generate_reply_and_send("+14155551234", "Hey, what's the weather?")
+    """
+
+    def __init__(
+        self,
+        system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+        model: str = "claude-sonnet-4-20250514",
+        max_tokens: int = 1024,
+        config_file: str = "",
+        anthropic_api_key: str = "",
+        dry_run: bool = False,
+    ):
+        self.system_prompt = system_prompt
+        self.model = model
+        self.max_tokens = max_tokens
+        self.config_file = config_file
+        self.dry_run = dry_run
+
+        # Conversation history: phone_number -> list of {"role": ..., "content": ...}
+        self._conversations: dict[str, list[dict[str, str]]] = defaultdict(list)
+
+        # Lazy-init the Anthropic client
+        self._anthropic_key = anthropic_api_key
+        self._client = None
+
+    @property
+    def client(self):
+        """Lazy-load anthropic client (so import isn't required at module level)."""
+        if self._client is None:
+            import anthropic
+            key = self._anthropic_key or _load_anthropic_key()
+            self._client = anthropic.Anthropic(api_key=key)
+        return self._client
+
+    def get_history(self, phone: str) -> list[dict[str, str]]:
+        """Get conversation history for a contact."""
+        return list(self._conversations[phone])
+
+    def clear_history(self, phone: str) -> None:
+        """Clear conversation history for a contact."""
+        self._conversations[phone].clear()
+
+    def add_message(self, phone: str, role: str, content: str) -> None:
+        """Add a message to conversation history, trimming if needed."""
+        history = self._conversations[phone]
+        history.append({"role": role, "content": content})
+        # Trim oldest messages if over limit (keep pairs to maintain alternation)
+        while len(history) > MAX_CONVERSATION_HISTORY:
+            history.pop(0)
+
+    def generate_reply(self, phone: str, incoming_message: str) -> str:
+        """Generate a Claude reply for an incoming WhatsApp message.
+
+        Adds the incoming message to history, calls Claude, adds the reply
+        to history, and returns it. Does NOT send the reply via WhatsApp.
+
+        Args:
+            phone: Sender phone number (used as conversation key).
+            incoming_message: The text message received.
+
+        Returns:
+            Claude's reply text.
+        """
+        phone = _normalize_phone(phone)
+        self.add_message(phone, "user", incoming_message)
+
+        response = self.client.messages.create(
+            model=self.model,
+            max_tokens=self.max_tokens,
+            system=self.system_prompt,
+            messages=self._conversations[phone],
+        )
+        reply_text = response.content[0].text
+        self.add_message(phone, "assistant", reply_text)
+        log.info("Claude reply for %s (%d tokens): %s",
+                 phone, response.usage.output_tokens, reply_text[:100])
+        return reply_text
+
+    def generate_reply_and_send(self, phone: str, incoming_message: str) -> str:
+        """Generate a Claude reply and send it back via WhatsApp.
+
+        Args:
+            phone: Sender phone number.
+            incoming_message: The text message received.
+
+        Returns:
+            The reply text that was sent.
+        """
+        reply = self.generate_reply(phone, incoming_message)
+        send_whatsapp_message(
+            to=phone,
+            message=reply,
+            config_file=self.config_file,
+            dry_run=self.dry_run,
+        )
+        return reply
+
+
+# ── Webhook server (Flask) ───────────────────────────────────────────
+
+def _verify_webhook_signature(payload: bytes, signature: str, app_secret: str) -> bool:
+    """Verify the X-Hub-Signature-256 header from Meta webhooks."""
+    if not signature or not app_secret:
+        return True  # skip verification if no secret configured
+    expected = "sha256=" + hmac.new(
+        app_secret.encode(), payload, hashlib.sha256
+    ).hexdigest()
+    return hmac.compare_digest(expected, signature)
+
+
+def _extract_messages(body: dict) -> list[dict[str, Any]]:
+    """Extract incoming text messages from a Meta webhook payload.
+
+    Returns a list of dicts with keys: from_phone, message_id, text, timestamp.
+    """
+    messages = []
+    for entry in body.get("entry", []):
+        for change in entry.get("changes", []):
+            value = change.get("value", {})
+            for msg in value.get("messages", []):
+                if msg.get("type") != "text":
+                    log.debug("Skipping non-text message type: %s", msg.get("type"))
+                    continue
+                messages.append({
+                    "from_phone": "+" + msg["from"],
+                    "message_id": msg["id"],
+                    "text": msg["text"]["body"],
+                    "timestamp": msg.get("timestamp", ""),
+                    "contact_name": _extract_contact_name(value, msg["from"]),
+                })
+    return messages
+
+
+def _extract_contact_name(value: dict, wa_id: str) -> str:
+    """Extract the contact's display name from webhook payload."""
+    for contact in value.get("contacts", []):
+        if contact.get("wa_id") == wa_id:
+            return contact.get("profile", {}).get("name", "")
+    return ""
+
+
+def create_whatsapp_webhook_app(
+    bot: WhatsAppClaudeBot | None = None,
+    verify_token: str = "",
+    app_secret: str = "",
+    auto_reply: bool = True,
+    auto_mark_read: bool = True,
+    on_message: Any = None,
+) -> Any:
+    """Create a Flask app that serves as a WhatsApp webhook endpoint.
+
+    Args:
+        bot: WhatsAppClaudeBot instance. Created automatically if None.
+        verify_token: Token for Meta webhook verification (GET requests).
+                      If empty, reads from whatsapp config's "verify_token" field.
+        app_secret: Meta app secret for signature verification. Optional.
+        auto_reply: If True, automatically generate and send Claude replies.
+        auto_mark_read: If True, mark incoming messages as read.
+        on_message: Optional callback(phone, text, reply) called after each message.
+
+    Returns:
+        Flask app instance.
+    """
+    from flask import Flask, request, jsonify
+
+    app = Flask(__name__)
+
+    if bot is None:
+        bot = WhatsAppClaudeBot()
+
+    # Resolve verify_token from config if not provided
+    if not verify_token:
+        try:
+            config = _load_config(bot.config_file)
+            verify_token = config.get("verify_token", "")
+        except FileNotFoundError:
+            pass
+
+    @app.route("/webhook", methods=["GET"])
+    def webhook_verify():
+        """Handle Meta webhook verification (challenge-response)."""
+        mode = request.args.get("hub.mode")
+        token = request.args.get("hub.verify_token")
+        challenge = request.args.get("hub.challenge")
+
+        if mode == "subscribe" and token == verify_token:
+            log.info("Webhook verified successfully")
+            return challenge, 200
+        log.warning("Webhook verification failed: mode=%s token_match=%s", mode, token == verify_token)
+        return "Forbidden", 403
+
+    @app.route("/webhook", methods=["POST"])
+    def webhook_receive():
+        """Handle incoming WhatsApp messages from Meta."""
+        payload = request.get_data()
+
+        # Verify signature if app_secret is configured
+        signature = request.headers.get("X-Hub-Signature-256", "")
+        if app_secret and not _verify_webhook_signature(payload, signature, app_secret):
+            log.warning("Invalid webhook signature")
+            return "Invalid signature", 403
+
+        body = request.get_json(silent=True)
+        if not body:
+            return "OK", 200
+
+        # Extract text messages
+        incoming = _extract_messages(body)
+        for msg in incoming:
+            phone = msg["from_phone"]
+            text = msg["text"]
+            name = msg["contact_name"]
+            log.info("Received from %s (%s): %s", phone, name or "unknown", text[:100])
+
+            # Mark as read
+            if auto_mark_read:
+                try:
+                    mark_as_read(msg["message_id"], config_file=bot.config_file)
+                except Exception as e:
+                    log.warning("Failed to mark message as read: %s", e)
+
+            # Generate and send Claude reply
+            reply = ""
+            if auto_reply:
+                try:
+                    reply = bot.generate_reply_and_send(phone, text)
+                    log.info("Replied to %s: %s", phone, reply[:100])
+                except Exception as e:
+                    log.error("Failed to reply to %s: %s", phone, e)
+
+            # Call user callback
+            if on_message:
+                try:
+                    on_message(phone, text, reply)
+                except Exception as e:
+                    log.error("on_message callback error: %s", e)
+
+        return "OK", 200
+
+    @app.route("/health", methods=["GET"])
+    def health():
+        return jsonify({"status": "ok", "bot_model": bot.model}), 200
+
+    return app
+
+
+def run_whatsapp_bot(
+    host: str = "0.0.0.0",
+    port: int = 5000,
+    debug: bool = True,
+    system_prompt: str = DEFAULT_SYSTEM_PROMPT,
+    model: str = "claude-sonnet-4-20250514",
+    config_file: str = "",
+    verify_token: str = "",
+    app_secret: str = "",
+    auto_reply: bool = True,
+    dry_run: bool = False,
+) -> None:
+    """Start the WhatsApp Claude bot webhook server.
+
+    This is the main entry point — run this and point your Meta webhook to
+    http://YOUR_HOST:PORT/webhook
+
+    Args:
+        host: Bind address (default: 0.0.0.0 for all interfaces).
+        port: Port to listen on (default: 5000).
+        debug: Flask debug mode.
+        system_prompt: System prompt for Claude.
+        model: Anthropic model name.
+        config_file: Path to WhatsApp API config JSON.
+        verify_token: Webhook verification token.
+        app_secret: Meta app secret for signature verification.
+        auto_reply: If True, auto-reply with Claude. If False, just logs messages.
+        dry_run: If True, don't actually send WhatsApp messages.
+    """
+    bot = WhatsAppClaudeBot(
+        system_prompt=system_prompt,
+        model=model,
+        config_file=config_file,
+        dry_run=dry_run,
+    )
+    app = create_whatsapp_webhook_app(
+        bot=bot,
+        verify_token=verify_token,
+        app_secret=app_secret,
+        auto_reply=auto_reply,
+    )
+    print(f"Starting WhatsApp Claude bot on {host}:{port}")
+    print(f"  Model: {model}")
+    print(f"  Auto-reply: {auto_reply}")
+    print(f"  Dry-run: {dry_run}")
+    print(f"  Webhook URL: http://{host}:{port}/webhook")
+    print(f"  Health check: http://{host}:{port}/health")
+    app.run(host=host, port=port, debug=debug)
+
+
 # ── Smoke test ────────────────────────────────────────────────────────
 
 if __name__ == "__main__":
@@ -260,4 +665,40 @@ if __name__ == "__main__":
     assert _normalize_phone("whatsapp:+14155551234") == "+14155551234"
     print("Phone normalization tests passed ✓")
 
-    print("All dry-run smoke tests passed!")
+    # Test message extraction
+    sample_webhook_payload = {
+        "entry": [{
+            "changes": [{
+                "value": {
+                    "messages": [{
+                        "from": "14155551234",
+                        "id": "wamid.test123",
+                        "type": "text",
+                        "text": {"body": "Hello!"},
+                        "timestamp": "1234567890",
+                    }],
+                    "contacts": [{
+                        "wa_id": "14155551234",
+                        "profile": {"name": "Test User"},
+                    }],
+                },
+            }],
+        }],
+    }
+    extracted = _extract_messages(sample_webhook_payload)
+    assert len(extracted) == 1
+    assert extracted[0]["from_phone"] == "+14155551234"
+    assert extracted[0]["text"] == "Hello!"
+    assert extracted[0]["contact_name"] == "Test User"
+    print("Message extraction tests passed ✓")
+
+    # Test WhatsAppClaudeBot conversation management (no API calls)
+    bot = WhatsAppClaudeBot(dry_run=True)
+    bot.add_message("+14155551234", "user", "Hi there")
+    bot.add_message("+14155551234", "assistant", "Hello!")
+    assert len(bot.get_history("+14155551234")) == 2
+    bot.clear_history("+14155551234")
+    assert len(bot.get_history("+14155551234")) == 0
+    print("Bot conversation management tests passed ✓")
+
+    print("\nAll dry-run smoke tests passed!")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ dependencies = [
     "sentencepiece",
 ]
 
+[project.optional-dependencies]
+whatsapp = ["flask>=3.0"]
+
 [project.urls]
 Homepage = "https://github.com/brando90/ultimate-utils"
 Repository = "https://github.com/brando90/ultimate-utils"


### PR DESCRIPTION
## Summary

- Adds `WhatsAppClaudeBot` class + Flask webhook server to `whatsapp_uu.py` so incoming WhatsApp messages get auto-replied by Claude
- Adds dry-run test suite (`playground/whatsapp_claude/test_whatsapp_claude_bot.py`) — all 6 tests pass with no API keys needed
- Adds `flask` as optional dependency (`pip install -e ".[whatsapp]"`)

Closes #34

---

## Step-by-Step Setup Guide (what you need to do)

### Step 1: Create a Meta Business Account (5 min)

1. Go to https://business.facebook.com/
2. Click "Create Account"
3. Use your real name / business name (personal is fine — "Brando Research" or whatever)
4. Confirm your email

### Step 2: Create a Meta Developer App (5 min)

1. Go to https://developers.facebook.com/apps/
2. Click **"Create App"**
3. Choose app type: **"Business"**
4. Give it a name like "WhatsApp Claude Bot"
5. Select your Business Account from Step 1
6. Click **"Create App"**

### Step 3: Add WhatsApp to Your App (2 min)

1. In your new app's dashboard, find **"Add Products"** in the left sidebar
2. Find **"WhatsApp"** and click **"Set Up"**
3. It will walk you through connecting your Business Account

### Step 4: Get Your Credentials (5 min)

In the Meta Developer Dashboard, go to **WhatsApp → API Setup**. You'll see:

1. **Phone Number ID** — displayed on the page (a numeric string like `123456789012345`)
2. **Access Token** — click "Generate" for a temporary token (lasts 24h), or for a permanent one:
   - Go to **Business Settings → System Users → Add** → create a system user
   - Give it admin role, then **Generate Token** with `whatsapp_business_messaging` permission
3. **Test Phone Number** — Meta gives you a free test number to send from (shown on API Setup page)
4. **App Secret** — go to **App Settings → Basic** → reveal the App Secret

### Step 5: Save Your Credentials Locally (2 min)

```bash
# Create the config file
cat > ~/keys/whatsapp_api_config.json << 'JSON'
{
    "provider": "meta",
    "access_token": "PASTE_YOUR_ACCESS_TOKEN_HERE",
    "phone_number_id": "PASTE_YOUR_PHONE_NUMBER_ID_HERE",
    "api_version": "v21.0",
    "verify_token": "pick_any_secret_string_you_want_like_uutils_whatsapp_2024"
}
JSON
chmod 600 ~/keys/whatsapp_api_config.json

# Make sure your Anthropic key is set
export ANTHROPIC_API_KEY="sk-ant-your-key-here"
# OR save it to a file:
# echo "sk-ant-your-key-here" > ~/keys/anthropic_api_key.txt && chmod 600 ~/keys/anthropic_api_key.txt
```

### Step 6: Expose Your Local Server to the Internet (2 min)

Meta needs to reach your computer via HTTPS. Easiest way:

```bash
# Install ngrok (one time)
# Mac: brew install ngrok
# Linux: snap install ngrok
# Or download from https://ngrok.com/download

# Start the tunnel
ngrok http 5000
```

ngrok will show something like: `https://abc123.ngrok-free.app` — **copy this URL**.

### Step 7: Configure the Webhook in Meta (3 min)

1. In Meta Developer Dashboard, go to **WhatsApp → Configuration**
2. Under **Webhook**, click **"Edit"**
3. **Callback URL:** paste your ngrok URL + `/webhook`, e.g.: `https://abc123.ngrok-free.app/webhook`
4. **Verify Token:** paste the same `verify_token` you put in your config (e.g., `uutils_whatsapp_2024`)
5. Click **"Verify and Save"** — Meta will ping your server (must be running first! See Step 8)
6. Under **Webhook Fields**, click **"Manage"** and subscribe to **`messages`**

### Step 8: Start the Bot! (1 min)

```bash
# Start the WhatsApp Claude bot
python playground/whatsapp_claude/test_whatsapp_claude_bot.py --serve

# Or from Python:
# from uutils.whatsapp_uu import run_whatsapp_bot
# run_whatsapp_bot()
```

**Important:** Start the bot BEFORE Step 7's "Verify and Save" — Meta needs to reach `/webhook` to verify.

### Step 9: Test It

1. Meta gives you up to 5 test phone numbers in the API Setup page
2. Add your personal phone number as a test recipient
3. Send a message to the WhatsApp Business number from your phone
4. Claude should auto-reply within a few seconds!

---

## Quick Reference — What Each Credential Is

| Credential | Where to find it | What it does |
|---|---|---|
| `access_token` | WhatsApp → API Setup → Generate Token | Authenticates your API calls to send messages |
| `phone_number_id` | WhatsApp → API Setup (shown on page) | Identifies which WhatsApp number to send from |
| `verify_token` | You make this up (any string) | Meta sends this back during webhook setup to prove it's you |
| `app_secret` | App Settings → Basic (optional) | Verifies webhook payloads are really from Meta |
| `ANTHROPIC_API_KEY` | console.anthropic.com | For Claude to generate replies |

## Test plan

- [x] Dry-run tests pass (no API keys): `python playground/whatsapp_claude/test_whatsapp_claude_bot.py`
- [ ] Claude integration test with API key: `python playground/whatsapp_claude/test_whatsapp_claude_bot.py --claude`
- [ ] Full webhook + send test: `python playground/whatsapp_claude/test_whatsapp_claude_bot.py --full`
- [ ] End-to-end with real WhatsApp Business account

https://claude.ai/code/session_01TYqKRGFxpAo5GY1SnGFLh3