### PR TITLE
Add Validity-Stability (M^C / M^VS): proxy-target correlation discounted by proxy stability

### DIFF
--- a/py_src/uutils/plot/validity_stability_scatter.py
+++ b/py_src/uutils/plot/validity_stability_scatter.py
@@ -1,0 +1,170 @@
+"""
+Validity-Stability scatter: proxy-vs-target per-item plot with a light 2D
+density wash and the VS-score formula (plugged in with real numbers) as the
+legend -- a drop-in replacement for "scatter plot + bare correlation in the
+title" whenever the proxy's own repeat-stability matters to whether you'd
+trust it, merged into a single, uncrowded panel rather than separate marginal
+histogram subplots.
+
+See uutils.stats_uu.validity_stability for the score this figure visualizes
+and for why the stability term must come from repeated measurements of the
+proxy, not from the spread of its scores across items.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Optional, Sequence, Union
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
+
+from uutils.stats_uu.validity_stability import compute_validity_stability
+
+try:
+    from scipy.stats import gaussian_kde
+
+    _HAVE_SCIPY_KDE = True
+except ImportError:  # pragma: no cover - scipy is a declared dependency
+    _HAVE_SCIPY_KDE = False
+
+
+# Validated sequential-blue ramp + chart chrome (Claude Code dataviz-skill
+# reference palette: colorblind-checked, see that skill's references/palette.md).
+_SEQ_BLUE = ["#fcfcfb", "#cde2fb", "#9ec5f4", "#6da7ec", "#3987e5", "#1c5cab"]
+_POINT_COLOR = "#2a78d6"  # categorical slot 1
+_DIAGONAL_COLOR = "#c3c2b7"  # baseline / axis
+_GRID_COLOR = "#e1e0d9"  # hairline gridline
+_TEXT_MUTED = "#898781"
+_TEXT_PRIMARY = "#0b0b0b"
+_SURFACE = "#fcfcfb"
+
+
+def _sequential_blue_cmap() -> LinearSegmentedColormap:
+    return LinearSegmentedColormap.from_list("vs_seq_blue", _SEQ_BLUE, N=256)
+
+
+def plot_validity_stability_scatter(
+    proxy_scores: Sequence[float],
+    target_scores: Sequence[float],
+    repeat_scores_by_item: Optional[Mapping[object, Sequence[float]]] = None,
+    *,
+    std: Optional[float] = None,
+    corr_method: str = "spearman",
+    symbol: str = "VS",
+    label: str = "",
+    x_label: str = "Target score",
+    y_label: str = "Proxy score",
+    show_density: bool = True,
+    show_diagonal: bool = True,
+    ax: Optional[plt.Axes] = None,
+    legend_loc: str = "best",
+    seed: int = 0,
+    out: Optional[Union[str, Path]] = None,
+) -> plt.Figure:
+    """
+    One panel: item-level (target, proxy) score scatter with a light 2D
+    density wash and the Validity-Stability formula -- plugged in with this
+    proxy's actual numbers -- as the legend.
+
+    Deterministic: `seed` only perturbs the KDE fit by float noise (1e-6) to
+    avoid a singular covariance matrix on near-duplicate points; identical
+    inputs + seed produce byte-identical figures. Pass `ax` to compose this
+    panel into a larger figure; otherwise a new figure is created. Pass
+    `symbol` to relabel the legend for a domain-specific instantiation (e.g.
+    cert-judge's TI_2') without changing the underlying math.
+    """
+    result = compute_validity_stability(
+        proxy_scores, target_scores, repeat_scores_by_item, std=std, corr_method=corr_method
+    )
+    x = np.asarray(target_scores, dtype=float)
+    y = np.asarray(proxy_scores, dtype=float)
+
+    owns_fig = ax is None
+    if owns_fig:
+        fig, ax = plt.subplots(figsize=(6.0, 5.2))
+    else:
+        fig = ax.figure
+
+    ax.set_facecolor(_SURFACE)
+
+    if show_density and _HAVE_SCIPY_KDE and result.n_items >= 5:
+        try:
+            rng = np.random.default_rng(seed)
+            jx = x + rng.normal(scale=1e-6, size=x.shape)
+            jy = y + rng.normal(scale=1e-6, size=y.shape)
+            kde = gaussian_kde(np.vstack([jx, jy]))
+            pad = 0.06
+            gx, gy = np.mgrid[-pad : 1 + pad : 120j, -pad : 1 + pad : 120j]
+            density = kde(np.vstack([gx.ravel(), gy.ravel()])).reshape(gx.shape)
+            ax.contourf(gx, gy, density, levels=12, cmap=_sequential_blue_cmap(), alpha=0.55, zorder=1)
+        except Exception:
+            pass  # cosmetic-only background wash; a degenerate point cloud just skips it
+
+    if show_diagonal:
+        ax.plot(
+            [-0.05, 1.05], [-0.05, 1.05], "--", color=_DIAGONAL_COLOR, linewidth=1.1,
+            alpha=0.9, zorder=2, label="perfect agreement (y = x)",
+        )
+
+    ax.scatter(
+        x, y, s=60, color=_POINT_COLOR, edgecolor="white", linewidth=0.6, alpha=0.9,
+        zorder=3, label=result.formula_str(symbol=symbol),
+    )
+
+    ax.set_xlim(-0.05, 1.05)
+    ax.set_ylim(-0.05, 1.05)
+    ax.set_xlabel(x_label, color=_TEXT_PRIMARY)
+    ax.set_ylabel(y_label, color=_TEXT_PRIMARY)
+    title = f"{label} — item-level alignment (n={result.n_items})" if label else (
+        f"Item-level alignment (n={result.n_items})"
+    )
+    ax.set_title(title, color=_TEXT_PRIMARY, fontsize=11, fontweight="bold", pad=8)
+    ax.grid(True, color=_GRID_COLOR, linewidth=0.8, alpha=0.9, zorder=0)
+    ax.tick_params(colors=_TEXT_MUTED)
+    for spine in ax.spines.values():
+        spine.set_color(_GRID_COLOR)
+
+    legend = ax.legend(
+        loc=legend_loc, frameon=True, framealpha=0.95, facecolor="white",
+        edgecolor="#cfcfcf", fontsize=9, borderpad=0.5,
+    )
+    legend.set_zorder(5)
+
+    if owns_fig:
+        fig.tight_layout()
+
+    if out is not None:
+        # `out` is a path *stem* (no extension) -- append, don't use with_suffix():
+        # with_suffix() replaces everything after the LAST dot in the stem, which
+        # mangles any stem containing a dot (e.g. a model name like "gpt-5.3-codex").
+        out_path = Path(out)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        # bbox_inches="tight": a long `label` (e.g. a full judge_id) can make the
+        # title wider than the figure canvas; savefig crops to the canvas by
+        # default instead of expanding it, silently clipping the overflow.
+        fig.savefig(f"{out_path}.png", dpi=300, facecolor=fig.get_facecolor(), bbox_inches="tight")
+        fig.savefig(f"{out_path}.pdf", facecolor=fig.get_facecolor(), bbox_inches="tight")
+
+    return fig
+
+
+def plot_validity_stability_scatter_test() -> None:
+    """Headless smoke test: builds a figure from synthetic data on the Agg backend."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    rng = np.random.default_rng(0)
+    target = rng.uniform(0, 1, size=40)
+    proxy = np.clip(target + rng.normal(0, 0.1, size=40), 0, 1)
+    repeats = {i: [v, v + rng.normal(0, 0.02), v + rng.normal(0, 0.02)] for i, v in enumerate(proxy)}
+    fig = plot_validity_stability_scatter(proxy, target, repeats, label="synthetic demo")
+    assert fig is not None
+    plt.close(fig)
+    print("plot_validity_stability_scatter_test passed")
+
+
+if __name__ == "__main__":
+    plot_validity_stability_scatter_test()
+    print("Done, success! \a")

--- a/py_src/uutils/plot/validity_stability_scatter.py
+++ b/py_src/uutils/plot/validity_stability_scatter.py
@@ -1,24 +1,26 @@
 """
 Validity-Stability scatter: proxy-vs-target item-level joint plot.
 
-Two layers that must not be confused with each other:
+Every element earns its place by being interpretable -- a reader looks at
+everything on the canvas and asks what it means, so nothing is decoration:
 
-  - HONEST / primary: one marker per DISTINCT (target, proxy) position, sized
-    by how many items share it, with a vertical error bar = that position's
-    mean repeat std (proxy self-consistency); discrete-aware (tie-snapped)
-    marginal histograms on top/right; the correlation (validity) with a
-    bootstrap CI. This is what alignment and stability are actually read
-    from, and none of it depends on a smoothness assumption the tie-heavy
-    data doesn't support.
-  - DECORATIVE / secondary: a light 2D density wash behind the central
-    markers, and a 1D KDE line over each marginal histogram, purely for
-    visual texture. These are never the thing you read dependence off of --
-    a 2D density can't distinguish a perfectly-aligned proxy from a shuffled
-    one (shuffling changes nothing about either marginal, or a 2D density
-    fit that ignores pairing order, while sending the correlation to zero),
-    which is exactly why it stays decorative rather than becoming the
-    figure's main claim. Turn both off with `show_density_shading=False`,
-    `show_marginal_kde=False` if you'd rather not have them at all.
+  - Central panel: one marker per DISTINCT (target, proxy) position, sized by
+    how many items share it (the count encoding a tie-heavy lattice needs
+    instead of a smoothed density), with a vertical error bar = that
+    position's mean repeat std (proxy self-consistency).
+  - Marginal histograms (top/right), discrete-aware (tie-snapped) -- the m0
+    diagnostic -- with an optional 1D KDE line over each for shape legibility
+    (`show_marginal_kde`, on by default). A 1D density of one variable is a
+    normal, safe smoothing choice; nothing about it can be mistaken for
+    evidence of a relationship between two variables.
+  - The correlation (validity) with a bootstrap CI, plus Kendall tau-b.
+
+No 2D density wash in the central panel, even as decoration: a 2D density
+can't distinguish a perfectly-aligned proxy from a shuffled one (shuffling
+changes neither marginal, only the pairing that the correlation summarizes),
+so drawing one -- however lightly -- invites a reader to read dependence off
+a channel that cannot carry it. `show_density_shading=True` still exists for
+a non-publication, illustrative-only rendering, but defaults off.
 
 Deliberately NOT drawing a y=x reference line by default: proxy and target
 are frequently on uncalibrated scales (e.g. a judge's rubric vs a human's
@@ -181,7 +183,7 @@ def plot_validity_stability_scatter(
     x_label: str = "Target score",
     y_label: str = "Proxy score",
     show_diagonal: bool = False,
-    show_density_shading: bool = True,
+    show_density_shading: bool = False,
     show_marginal_kde: bool = True,
     show_calibration_gap: bool = False,
     n_boot: int = 2000,
@@ -304,9 +306,17 @@ def plot_validity_stability_scatter(
     ax_c.set_ylim(-0.05, 1.05)
     ax_c.set_xlabel(x_label, color=_TEXT_PRIMARY, fontsize=9.5)
     ax_c.set_ylabel(y_label, color=_TEXT_PRIMARY, fontsize=9.5)
+    # Spelled out against the exact y_label (not the generic word "proxy") and
+    # against exactly what's computed, per second-pass review feedback that
+    # "proxy repeat SD" read as ambiguous -- a possessive ("the proxy's
+    # repeat SD") misreadable as "a proxy [substitute] for repeat SD". It
+    # is real per-item np.std() over that item's repeat_scores_by_item
+    # entries; at a position with >1 tied item this is the mean of those
+    # items' individual repeat SDs, not a substituted or estimated value.
+    y_label_core = y_label.split("(")[0].strip().lower()
     ax_c.text(
-        0.02, 0.02, "dot size = # tied items; error bar = proxy repeat SD", transform=ax_c.transAxes,
-        fontsize=6.8, color=_TEXT_MUTED, va="bottom", ha="left",
+        0.02, 0.02, f"dot size = # tied items  ·  error bar = repeat SD of the {y_label_core}",
+        transform=ax_c.transAxes, fontsize=6.8, color=_TEXT_MUTED, va="bottom", ha="left",
     )
 
     _style_axes(ax_top)

--- a/py_src/uutils/plot/validity_stability_scatter.py
+++ b/py_src/uutils/plot/validity_stability_scatter.py
@@ -1,29 +1,33 @@
 """
 Validity-Stability scatter: proxy-vs-target item-level joint plot.
 
-    - Central panel: one marker per DISTINCT (target, proxy) position, sized
-      by how many items share it, with a vertical error bar = that
-      position's mean repeat std (judge/proxy self-consistency).
-    - Top / right marginal panels: discrete-aware (tie-snapped) histograms of
-      the target and proxy distributions.
-    - Info panel: the VS-score formula with real numbers plugged in, a
-      bootstrap CI on the correlation, Kendall tau-b, and (optionally) a
-      calibration-gap diagnostic.
+Two layers that must not be confused with each other:
 
-Deliberately NOT a 2D kernel density estimate. At small n with heavy ties
-(e.g. n=72 over ~9 distinct target values -- a lattice, not a continuum) a
-smooth 2D density implies dependence structure that isn't there and can make
-a perfectly-aligned judge and a shuffled judge look visually similar, since
-both share the same *marginals* -- only the joint pairing (summarized by the
-correlation) tells them apart. See uutils.stats_uu.validity_stability for the
-score this figure visualizes.
+  - HONEST / primary: one marker per DISTINCT (target, proxy) position, sized
+    by how many items share it, with a vertical error bar = that position's
+    mean repeat std (proxy self-consistency); discrete-aware (tie-snapped)
+    marginal histograms on top/right; the correlation (validity) with a
+    bootstrap CI. This is what alignment and stability are actually read
+    from, and none of it depends on a smoothness assumption the tie-heavy
+    data doesn't support.
+  - DECORATIVE / secondary: a light 2D density wash behind the central
+    markers, and a 1D KDE line over each marginal histogram, purely for
+    visual texture. These are never the thing you read dependence off of --
+    a 2D density can't distinguish a perfectly-aligned proxy from a shuffled
+    one (shuffling changes nothing about either marginal, or a 2D density
+    fit that ignores pairing order, while sending the correlation to zero),
+    which is exactly why it stays decorative rather than becoming the
+    figure's main claim. Turn both off with `show_density_shading=False`,
+    `show_marginal_kde=False` if you'd rather not have them at all.
 
-Deliberately NOT drawing a y=x reference line by default either: proxy and
-target are frequently on uncalibrated scales (e.g. a judge's rubric vs a
-human's rubric), and the validity score is correlation-based -- invariant to
-a level offset by construction -- so y=x would imply a calibration target the
-score does not claim. Pass `show_diagonal=True` when proxy and target really
-are on the same calibrated scale.
+Deliberately NOT drawing a y=x reference line by default: proxy and target
+are frequently on uncalibrated scales (e.g. a judge's rubric vs a human's
+rubric), and the validity score is correlation-based -- invariant to a level
+offset by construction -- so y=x would imply a calibration target the score
+does not claim. Pass `show_diagonal=True` when proxy and target really are on
+the same calibrated scale.
+
+See uutils.stats_uu.validity_stability for the score this figure visualizes.
 """
 
 from __future__ import annotations
@@ -34,6 +38,7 @@ from typing import Mapping, Optional, Sequence, Union
 
 import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib.colors import LinearSegmentedColormap
 
 from uutils.stats_uu.validity_stability import (
     compute_validity_stability,
@@ -41,6 +46,13 @@ from uutils.stats_uu.validity_stability import (
     compute_kendall_tau_b,
     compute_calibration_gap,
 )
+
+try:
+    from scipy.stats import gaussian_kde
+
+    _HAVE_SCIPY_KDE = True
+except ImportError:  # pragma: no cover - scipy is a declared dependency
+    _HAVE_SCIPY_KDE = False
 
 # Chart chrome (Claude Code dataviz-skill reference palette).
 _POINT_COLOR = "#2a78d6"  # categorical slot 1
@@ -51,6 +63,11 @@ _GRID_COLOR = "#e1e0d9"  # hairline gridline
 _TEXT_MUTED = "#898781"
 _TEXT_PRIMARY = "#0b0b0b"
 _SURFACE = "#fcfcfb"
+_SEQ_BLUE = ["#fcfcfb", "#cde2fb", "#9ec5f4", "#6da7ec", "#3987e5", "#1c5cab"]
+
+
+def _sequential_blue_cmap() -> LinearSegmentedColormap:
+    return LinearSegmentedColormap.from_list("vs_seq_blue", _SEQ_BLUE, N=256)
 
 
 def _discrete_bin_edges(
@@ -110,6 +127,48 @@ def _style_axes(ax: plt.Axes) -> None:
         spine.set_color(_GRID_COLOR)
 
 
+def _add_density_wash(ax: plt.Axes, x: np.ndarray, y: np.ndarray, seed: int, alpha: float = 0.4) -> None:
+    """Decorative-only 2D density texture behind the honest markers -- see module docstring."""
+    if not _HAVE_SCIPY_KDE or x.shape[0] < 5:
+        return
+    try:
+        rng = np.random.default_rng(seed)
+        jx = x + rng.normal(scale=1e-6, size=x.shape)
+        jy = y + rng.normal(scale=1e-6, size=y.shape)
+        kde = gaussian_kde(np.vstack([jx, jy]))
+        pad = 0.06
+        gx, gy = np.mgrid[-pad : 1 + pad : 120j, -pad : 1 + pad : 120j]
+        density = kde(np.vstack([gx.ravel(), gy.ravel()])).reshape(gx.shape)
+        ax.contourf(gx, gy, density, levels=12, cmap=_sequential_blue_cmap(), alpha=alpha, zorder=1)
+    except Exception:
+        pass  # decorative only -- a degenerate point cloud just skips it
+
+
+def _marginal_hist(
+    ax: plt.Axes, data: np.ndarray, orientation: str, seed: int, show_kde: bool
+) -> None:
+    """Discrete-aware histogram (the real m0 diagnostic) with an optional decorative 1D KDE line."""
+    edges = _discrete_bin_edges(data)
+    ax.hist(
+        data, bins=edges, density=True, orientation=orientation, color=_HIST_COLOR,
+        edgecolor="white", linewidth=0.5, zorder=2,
+    )
+    n_uniq = np.unique(np.round(data, 6)).size
+    if show_kde and _HAVE_SCIPY_KDE and n_uniq >= 3:
+        try:
+            rng = np.random.default_rng(seed)
+            jittered = data + rng.normal(scale=1e-6, size=data.shape)
+            kde = gaussian_kde(jittered)
+            grid = np.linspace(-0.05, 1.05, 200)
+            density = kde(grid)
+            if orientation == "vertical":
+                ax.plot(grid, density, color=_ERRORBAR_COLOR, linewidth=1.4, alpha=0.9, zorder=3)
+            else:
+                ax.plot(density, grid, color=_ERRORBAR_COLOR, linewidth=1.4, alpha=0.9, zorder=3)
+        except Exception:
+            pass  # decorative only
+
+
 def plot_validity_stability_scatter(
     proxy_scores: Sequence[float],
     target_scores: Sequence[float],
@@ -122,7 +181,9 @@ def plot_validity_stability_scatter(
     x_label: str = "Target score",
     y_label: str = "Proxy score",
     show_diagonal: bool = False,
-    show_calibration_gap: bool = True,
+    show_density_shading: bool = True,
+    show_marginal_kde: bool = True,
+    show_calibration_gap: bool = False,
     n_boot: int = 2000,
     ax: Optional[plt.Axes] = None,
     legend_loc: str = "best",
@@ -131,9 +192,10 @@ def plot_validity_stability_scatter(
 ) -> plt.Figure:
     """
     Item-level (target, proxy) joint plot: count-sized markers with per-position
-    repeat-std error bars in the center, discrete-aware marginal histograms on
-    top/right, and an info panel with the VS-score formula plus a bootstrap CI
-    and Kendall tau-b.
+    repeat-std error bars over a light decorative density wash in the center,
+    discrete-aware marginal histograms (+ a decorative 1D KDE line) on
+    top/right, and a compact info panel with the VS-score formula, the
+    correlation with a bootstrap CI, and Kendall tau-b.
 
     If `repeat_scores_by_item` is given, it must be in the SAME item order as
     `proxy_scores`/`target_scores` (i.e. `list(repeat_scores_by_item.values())[i]`
@@ -142,10 +204,11 @@ def plot_validity_stability_scatter(
     per-item error bars. Without it, the central panel still shows count-sized
     markers, just without error bars.
 
-    Deterministic: `seed` drives the bootstrap CI; identical inputs + seed
-    produce byte-identical figures. Pass `ax` for a simplified single-panel
-    mode (no room to add marginal/info panels next to someone else's axes):
-    count-sized markers + error bars + a corner-overlay legend, no marginals.
+    Deterministic: `seed` drives the bootstrap CI and the (jittered) KDE fits;
+    identical inputs + seed produce byte-identical figures. Pass `ax` for a
+    simplified single-panel mode (no room to add marginal/info panels next to
+    someone else's axes): count-sized markers + error bars + density wash +
+    a corner-overlay legend, no marginals.
     """
     result = compute_validity_stability(
         proxy_scores, target_scores, repeat_scores_by_item, std=std, corr_method=corr_method
@@ -167,15 +230,15 @@ def plot_validity_stability_scatter(
 
     ci_lo, ci_hi = bootstrap_correlation_ci(y, x, corr_method=corr_method, n_boot=n_boot, seed=seed)
     tau_b = compute_kendall_tau_b(y, x)
+    corr_symbol = r"\rho" if corr_method == "spearman" else "r"
     info_lines = [
         result.formula_str(symbol=symbol),
-        rf"Spearman $\rho$" if corr_method == "spearman" else rf"Pearson $r$",
-        rf"  95% CI [{ci_lo:.2f}, {ci_hi:.2f}]  ({n_boot} bootstrap, item-level)",
-        rf"Kendall $\tau_b$ = {tau_b:.2f}  (ties-corrected; not used above)",
+        rf"${corr_symbol} = {result.validity_raw:.2f}$  [{ci_lo:.2f}, {ci_hi:.2f}] 95% CI",
+        rf"$\tau_b = {tau_b:.2f}$",
     ]
     if show_calibration_gap:
         gap = compute_calibration_gap(y, x)
-        info_lines.append(rf"Calibration gap (Wasserstein) = {gap:.2f}  (separate from alignment)")
+        info_lines.append(rf"Calibration gap = {gap:.2f}")
 
     xs_u, ys_u, counts, errs = _group_by_position(x, y, per_item_std)
     sizes = 30 + 25 * counts
@@ -189,6 +252,8 @@ def plot_validity_stability_scatter(
         # next to axes this function doesn't own.
         fig = ax.figure
         _style_axes(ax)
+        if show_density_shading:
+            _add_density_wash(ax, x, y, seed)
         if errs is not None:
             ax.errorbar(
                 xs_u, ys_u, yerr=errs, fmt="none", ecolor=_ERRORBAR_COLOR, elinewidth=1.1,
@@ -223,6 +288,8 @@ def plot_validity_stability_scatter(
     ax_info.axis("off")
 
     _style_axes(ax_c)
+    if show_density_shading:
+        _add_density_wash(ax_c, x, y, seed)
     if errs is not None:
         ax_c.errorbar(
             xs_u, ys_u, yerr=errs, fmt="none", ecolor=_ERRORBAR_COLOR, elinewidth=1.1,
@@ -243,19 +310,16 @@ def plot_validity_stability_scatter(
     )
 
     _style_axes(ax_top)
-    ax_top.hist(x, bins=_discrete_bin_edges(x), color=_HIST_COLOR, edgecolor="white", linewidth=0.5)
-    ax_top.tick_params(labelbottom=False)
-    ax_top.set_ylabel("count", fontsize=7.5, color=_TEXT_MUTED)
+    _marginal_hist(ax_top, x, "vertical", seed, show_marginal_kde)
+    ax_top.tick_params(labelbottom=False, labelleft=False)
 
     _style_axes(ax_right)
-    ax_right.hist(y, bins=_discrete_bin_edges(y), orientation="horizontal", color=_HIST_COLOR,
-                   edgecolor="white", linewidth=0.5)
-    ax_right.tick_params(labelleft=False)
-    ax_right.set_xlabel("count", fontsize=7.5, color=_TEXT_MUTED)
+    _marginal_hist(ax_right, y, "horizontal", seed, show_marginal_kde)
+    ax_right.tick_params(labelleft=False, labelbottom=False)
 
     ax_info.text(
-        0.0, 1.0, "\n".join(info_lines), transform=ax_info.transAxes, fontsize=8.3,
-        color=_TEXT_PRIMARY, va="top", ha="left", linespacing=1.7,
+        0.0, 1.0, "\n".join(info_lines), transform=ax_info.transAxes, fontsize=9.5,
+        color=_TEXT_PRIMARY, va="top", ha="left", linespacing=1.9,
         bbox=dict(boxstyle="round,pad=0.4", facecolor="white", edgecolor="#cfcfcf", alpha=0.95),
     )
 
@@ -296,7 +360,7 @@ def _discrete_bin_edges_test() -> None:
 
 
 def plot_validity_stability_scatter_test() -> None:
-    """Headless smoke test: builds a full joint-plot figure from synthetic data."""
+    """Headless smoke test: builds a full joint-plot figure (density wash + marginal KDEs) from synthetic data."""
     import matplotlib
 
     matplotlib.use("Agg")

--- a/py_src/uutils/plot/validity_stability_scatter.py
+++ b/py_src/uutils/plot/validity_stability_scatter.py
@@ -1,39 +1,51 @@
 """
-Validity-Stability scatter: proxy-vs-target per-item plot with a light 2D
-density wash and the VS-score formula (plugged in with real numbers) as the
-legend -- a drop-in replacement for "scatter plot + bare correlation in the
-title" whenever the proxy's own repeat-stability matters to whether you'd
-trust it, merged into a single, uncrowded panel rather than separate marginal
-histogram subplots.
+Validity-Stability scatter: proxy-vs-target item-level joint plot.
 
-See uutils.stats_uu.validity_stability for the score this figure visualizes
-and for why the stability term must come from repeated measurements of the
-proxy, not from the spread of its scores across items.
+    - Central panel: one marker per DISTINCT (target, proxy) position, sized
+      by how many items share it, with a vertical error bar = that
+      position's mean repeat std (judge/proxy self-consistency).
+    - Top / right marginal panels: discrete-aware (tie-snapped) histograms of
+      the target and proxy distributions.
+    - Info panel: the VS-score formula with real numbers plugged in, a
+      bootstrap CI on the correlation, Kendall tau-b, and (optionally) a
+      calibration-gap diagnostic.
+
+Deliberately NOT a 2D kernel density estimate. At small n with heavy ties
+(e.g. n=72 over ~9 distinct target values -- a lattice, not a continuum) a
+smooth 2D density implies dependence structure that isn't there and can make
+a perfectly-aligned judge and a shuffled judge look visually similar, since
+both share the same *marginals* -- only the joint pairing (summarized by the
+correlation) tells them apart. See uutils.stats_uu.validity_stability for the
+score this figure visualizes.
+
+Deliberately NOT drawing a y=x reference line by default either: proxy and
+target are frequently on uncalibrated scales (e.g. a judge's rubric vs a
+human's rubric), and the validity score is correlation-based -- invariant to
+a level offset by construction -- so y=x would imply a calibration target the
+score does not claim. Pass `show_diagonal=True` when proxy and target really
+are on the same calibrated scale.
 """
 
 from __future__ import annotations
 
+from collections import defaultdict
 from pathlib import Path
 from typing import Mapping, Optional, Sequence, Union
 
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.colors import LinearSegmentedColormap
 
-from uutils.stats_uu.validity_stability import compute_validity_stability
+from uutils.stats_uu.validity_stability import (
+    compute_validity_stability,
+    bootstrap_correlation_ci,
+    compute_kendall_tau_b,
+    compute_calibration_gap,
+)
 
-try:
-    from scipy.stats import gaussian_kde
-
-    _HAVE_SCIPY_KDE = True
-except ImportError:  # pragma: no cover - scipy is a declared dependency
-    _HAVE_SCIPY_KDE = False
-
-
-# Validated sequential-blue ramp + chart chrome (Claude Code dataviz-skill
-# reference palette: colorblind-checked, see that skill's references/palette.md).
-_SEQ_BLUE = ["#fcfcfb", "#cde2fb", "#9ec5f4", "#6da7ec", "#3987e5", "#1c5cab"]
+# Chart chrome (Claude Code dataviz-skill reference palette).
 _POINT_COLOR = "#2a78d6"  # categorical slot 1
+_HIST_COLOR = "#9ec5f4"  # lighter step of the same hue, for the marginals
+_ERRORBAR_COLOR = "#184f95"  # darker step of the same hue
 _DIAGONAL_COLOR = "#c3c2b7"  # baseline / axis
 _GRID_COLOR = "#e1e0d9"  # hairline gridline
 _TEXT_MUTED = "#898781"
@@ -41,8 +53,61 @@ _TEXT_PRIMARY = "#0b0b0b"
 _SURFACE = "#fcfcfb"
 
 
-def _sequential_blue_cmap() -> LinearSegmentedColormap:
-    return LinearSegmentedColormap.from_list("vs_seq_blue", _SEQ_BLUE, N=256)
+def _discrete_bin_edges(
+    data: np.ndarray, pad_frac: float = 0.5, min_gap_fallback: float = 0.05, max_bins: int = 25
+) -> np.ndarray:
+    """
+    Bin edges at midpoints between sorted unique values, so ties never split
+    across bins -- for genuinely discrete/tie-heavy data (e.g. human labels
+    averaged from a handful of integer ratings). One-bin-per-unique-value only
+    makes sense while there are few enough values for that to be a histogram
+    rather than a list: past `max_bins` distinct values (e.g. a proxy whose
+    scores are closer to continuous), fall back to a regular grid over the
+    observed range -- still count-based, just not snapped to individual values.
+    """
+    uniq = np.unique(np.round(data, 6))
+    if uniq.size == 0:
+        return np.array([0.0, 1.0])
+    if uniq.size == 1:
+        return np.array([uniq[0] - min_gap_fallback, uniq[0] + min_gap_fallback])
+    if uniq.size <= max_bins:
+        gaps = np.diff(uniq)
+        min_gap = float(gaps.min())
+        return np.concatenate((
+            [uniq[0] - min_gap * pad_frac],
+            uniq[:-1] + gaps / 2.0,
+            [uniq[-1] + min_gap * pad_frac],
+        ))
+    lo, hi = float(uniq[0]), float(uniq[-1])
+    pad = (hi - lo) * 0.02 if hi > lo else min_gap_fallback
+    return np.linspace(lo - pad, hi + pad, max_bins + 1)
+
+
+def _group_by_position(x: np.ndarray, y: np.ndarray, per_item_std: Optional[np.ndarray]):
+    """Dedup (x, y) pairs for the scatter: count per position, mean repeat-std per position."""
+    groups: dict = defaultdict(list)
+    for i in range(x.shape[0]):
+        key = (round(float(x[i]), 6), round(float(y[i]), 6))
+        groups[key].append(per_item_std[i] if per_item_std is not None else None)
+    xs = np.array([k[0] for k in groups.keys()])
+    ys = np.array([k[1] for k in groups.keys()])
+    counts = np.array([len(v) for v in groups.values()])
+    if per_item_std is None:
+        return xs, ys, counts, None
+    errs = np.array([
+        float(np.nanmean([s for s in v if s is not None and np.isfinite(s)]))
+        if any(s is not None and np.isfinite(s) for s in v) else np.nan
+        for v in groups.values()
+    ])
+    return xs, ys, counts, errs
+
+
+def _style_axes(ax: plt.Axes) -> None:
+    ax.set_facecolor(_SURFACE)
+    ax.grid(True, color=_GRID_COLOR, linewidth=0.8, alpha=0.9, zorder=0)
+    ax.tick_params(colors=_TEXT_MUTED, labelsize=8)
+    for spine in ax.spines.values():
+        spine.set_color(_GRID_COLOR)
 
 
 def plot_validity_stability_scatter(
@@ -56,102 +121,182 @@ def plot_validity_stability_scatter(
     label: str = "",
     x_label: str = "Target score",
     y_label: str = "Proxy score",
-    show_density: bool = True,
-    show_diagonal: bool = True,
+    show_diagonal: bool = False,
+    show_calibration_gap: bool = True,
+    n_boot: int = 2000,
     ax: Optional[plt.Axes] = None,
     legend_loc: str = "best",
     seed: int = 0,
     out: Optional[Union[str, Path]] = None,
 ) -> plt.Figure:
     """
-    One panel: item-level (target, proxy) score scatter with a light 2D
-    density wash and the Validity-Stability formula -- plugged in with this
-    proxy's actual numbers -- as the legend.
+    Item-level (target, proxy) joint plot: count-sized markers with per-position
+    repeat-std error bars in the center, discrete-aware marginal histograms on
+    top/right, and an info panel with the VS-score formula plus a bootstrap CI
+    and Kendall tau-b.
 
-    Deterministic: `seed` only perturbs the KDE fit by float noise (1e-6) to
-    avoid a singular covariance matrix on near-duplicate points; identical
-    inputs + seed produce byte-identical figures. Pass `ax` to compose this
-    panel into a larger figure; otherwise a new figure is created. Pass
-    `symbol` to relabel the legend for a domain-specific instantiation (e.g.
-    cert-judge's TI_2') without changing the underlying math.
+    If `repeat_scores_by_item` is given, it must be in the SAME item order as
+    `proxy_scores`/`target_scores` (i.e. `list(repeat_scores_by_item.values())[i]`
+    is item i's repeats) -- this is the existing ordering contract already
+    required by `compute_validity_stability`'s pooling, extended here to
+    per-item error bars. Without it, the central panel still shows count-sized
+    markers, just without error bars.
+
+    Deterministic: `seed` drives the bootstrap CI; identical inputs + seed
+    produce byte-identical figures. Pass `ax` for a simplified single-panel
+    mode (no room to add marginal/info panels next to someone else's axes):
+    count-sized markers + error bars + a corner-overlay legend, no marginals.
     """
     result = compute_validity_stability(
         proxy_scores, target_scores, repeat_scores_by_item, std=std, corr_method=corr_method
     )
     x = np.asarray(target_scores, dtype=float)
     y = np.asarray(proxy_scores, dtype=float)
-
-    owns_fig = ax is None
-    if owns_fig:
-        fig, ax = plt.subplots(figsize=(6.0, 5.2))
+    if repeat_scores_by_item is not None:
+        if len(repeat_scores_by_item) != x.shape[0]:
+            raise ValueError(
+                f"repeat_scores_by_item has {len(repeat_scores_by_item)} entries but "
+                f"proxy_scores/target_scores have {x.shape[0]} -- must be item-aligned 1:1"
+            )
+        per_item_std = np.array([
+            float(np.std(np.asarray(v, dtype=float))) if len(v) > 1 else np.nan
+            for v in repeat_scores_by_item.values()
+        ])
     else:
-        fig = ax.figure
+        per_item_std = None
 
-    ax.set_facecolor(_SURFACE)
+    ci_lo, ci_hi = bootstrap_correlation_ci(y, x, corr_method=corr_method, n_boot=n_boot, seed=seed)
+    tau_b = compute_kendall_tau_b(y, x)
+    info_lines = [
+        result.formula_str(symbol=symbol),
+        rf"Spearman $\rho$" if corr_method == "spearman" else rf"Pearson $r$",
+        rf"  95% CI [{ci_lo:.2f}, {ci_hi:.2f}]  ({n_boot} bootstrap, item-level)",
+        rf"Kendall $\tau_b$ = {tau_b:.2f}  (ties-corrected; not used above)",
+    ]
+    if show_calibration_gap:
+        gap = compute_calibration_gap(y, x)
+        info_lines.append(rf"Calibration gap (Wasserstein) = {gap:.2f}  (separate from alignment)")
 
-    if show_density and _HAVE_SCIPY_KDE and result.n_items >= 5:
-        try:
-            rng = np.random.default_rng(seed)
-            jx = x + rng.normal(scale=1e-6, size=x.shape)
-            jy = y + rng.normal(scale=1e-6, size=y.shape)
-            kde = gaussian_kde(np.vstack([jx, jy]))
-            pad = 0.06
-            gx, gy = np.mgrid[-pad : 1 + pad : 120j, -pad : 1 + pad : 120j]
-            density = kde(np.vstack([gx.ravel(), gy.ravel()])).reshape(gx.shape)
-            ax.contourf(gx, gy, density, levels=12, cmap=_sequential_blue_cmap(), alpha=0.55, zorder=1)
-        except Exception:
-            pass  # cosmetic-only background wash; a degenerate point cloud just skips it
+    xs_u, ys_u, counts, errs = _group_by_position(x, y, per_item_std)
+    sizes = 30 + 25 * counts
 
-    if show_diagonal:
-        ax.plot(
-            [-0.05, 1.05], [-0.05, 1.05], "--", color=_DIAGONAL_COLOR, linewidth=1.1,
-            alpha=0.9, zorder=2, label="perfect agreement (y = x)",
-        )
-
-    ax.scatter(
-        x, y, s=60, color=_POINT_COLOR, edgecolor="white", linewidth=0.6, alpha=0.9,
-        zorder=3, label=result.formula_str(symbol=symbol),
-    )
-
-    ax.set_xlim(-0.05, 1.05)
-    ax.set_ylim(-0.05, 1.05)
-    ax.set_xlabel(x_label, color=_TEXT_PRIMARY)
-    ax.set_ylabel(y_label, color=_TEXT_PRIMARY)
     title = f"{label} — item-level alignment (n={result.n_items})" if label else (
         f"Item-level alignment (n={result.n_items})"
     )
-    ax.set_title(title, color=_TEXT_PRIMARY, fontsize=11, fontweight="bold", pad=8)
-    ax.grid(True, color=_GRID_COLOR, linewidth=0.8, alpha=0.9, zorder=0)
-    ax.tick_params(colors=_TEXT_MUTED)
-    for spine in ax.spines.values():
-        spine.set_color(_GRID_COLOR)
 
-    legend = ax.legend(
-        loc=legend_loc, frameon=True, framealpha=0.95, facecolor="white",
-        edgecolor="#cfcfcf", fontsize=9, borderpad=0.5,
+    if ax is not None:
+        # Simplified single-panel mode: no room to add marginal/info panels
+        # next to axes this function doesn't own.
+        fig = ax.figure
+        _style_axes(ax)
+        if errs is not None:
+            ax.errorbar(
+                xs_u, ys_u, yerr=errs, fmt="none", ecolor=_ERRORBAR_COLOR, elinewidth=1.1,
+                capsize=2.5, alpha=0.8, zorder=2,
+            )
+        if show_diagonal:
+            ax.plot([-0.05, 1.05], [-0.05, 1.05], "--", color=_DIAGONAL_COLOR, linewidth=1.1,
+                     alpha=0.9, zorder=1, label="y = x")
+        ax.scatter(xs_u, ys_u, s=sizes, color=_POINT_COLOR, edgecolor="white", linewidth=0.6,
+                    alpha=0.9, zorder=3, label="\n".join(info_lines))
+        ax.set_xlim(-0.05, 1.05)
+        ax.set_ylim(-0.05, 1.05)
+        ax.set_xlabel(x_label, color=_TEXT_PRIMARY)
+        ax.set_ylabel(y_label, color=_TEXT_PRIMARY)
+        ax.set_title(title, color=_TEXT_PRIMARY, fontsize=11, fontweight="bold", pad=8)
+        legend = ax.legend(loc=legend_loc, frameon=True, framealpha=0.95, facecolor="white",
+                            edgecolor="#cfcfcf", fontsize=8, borderpad=0.5)
+        legend.set_zorder(5)
+        if out is not None:
+            _save(fig, out)
+        return fig
+
+    fig = plt.figure(figsize=(7.4, 7.4))
+    gs = fig.add_gridspec(
+        2, 2, width_ratios=(4, 1.4), height_ratios=(1.4, 4),
+        left=0.11, right=0.97, bottom=0.09, top=0.93, wspace=0.06, hspace=0.06,
     )
-    legend.set_zorder(5)
+    ax_c = fig.add_subplot(gs[1, 0])
+    ax_top = fig.add_subplot(gs[0, 0], sharex=ax_c)
+    ax_right = fig.add_subplot(gs[1, 1], sharey=ax_c)
+    ax_info = fig.add_subplot(gs[0, 1])
+    ax_info.axis("off")
 
-    if owns_fig:
-        fig.tight_layout()
+    _style_axes(ax_c)
+    if errs is not None:
+        ax_c.errorbar(
+            xs_u, ys_u, yerr=errs, fmt="none", ecolor=_ERRORBAR_COLOR, elinewidth=1.1,
+            capsize=2.5, alpha=0.8, zorder=2,
+        )
+    if show_diagonal:
+        ax_c.plot([-0.05, 1.05], [-0.05, 1.05], "--", color=_DIAGONAL_COLOR, linewidth=1.1,
+                   alpha=0.9, zorder=1)
+    ax_c.scatter(xs_u, ys_u, s=sizes, color=_POINT_COLOR, edgecolor="white", linewidth=0.6,
+                  alpha=0.9, zorder=3)
+    ax_c.set_xlim(-0.05, 1.05)
+    ax_c.set_ylim(-0.05, 1.05)
+    ax_c.set_xlabel(x_label, color=_TEXT_PRIMARY, fontsize=9.5)
+    ax_c.set_ylabel(y_label, color=_TEXT_PRIMARY, fontsize=9.5)
+    ax_c.text(
+        0.02, 0.02, "dot size = # tied items; error bar = proxy repeat SD", transform=ax_c.transAxes,
+        fontsize=6.8, color=_TEXT_MUTED, va="bottom", ha="left",
+    )
+
+    _style_axes(ax_top)
+    ax_top.hist(x, bins=_discrete_bin_edges(x), color=_HIST_COLOR, edgecolor="white", linewidth=0.5)
+    ax_top.tick_params(labelbottom=False)
+    ax_top.set_ylabel("count", fontsize=7.5, color=_TEXT_MUTED)
+
+    _style_axes(ax_right)
+    ax_right.hist(y, bins=_discrete_bin_edges(y), orientation="horizontal", color=_HIST_COLOR,
+                   edgecolor="white", linewidth=0.5)
+    ax_right.tick_params(labelleft=False)
+    ax_right.set_xlabel("count", fontsize=7.5, color=_TEXT_MUTED)
+
+    ax_info.text(
+        0.0, 1.0, "\n".join(info_lines), transform=ax_info.transAxes, fontsize=8.3,
+        color=_TEXT_PRIMARY, va="top", ha="left", linespacing=1.7,
+        bbox=dict(boxstyle="round,pad=0.4", facecolor="white", edgecolor="#cfcfcf", alpha=0.95),
+    )
+
+    fig.suptitle(title, color=_TEXT_PRIMARY, fontsize=11.5, fontweight="bold", y=0.98)
 
     if out is not None:
-        # `out` is a path *stem* (no extension) -- append, don't use with_suffix():
-        # with_suffix() replaces everything after the LAST dot in the stem, which
-        # mangles any stem containing a dot (e.g. a model name like "gpt-5.3-codex").
-        out_path = Path(out)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        # bbox_inches="tight": a long `label` (e.g. a full judge_id) can make the
-        # title wider than the figure canvas; savefig crops to the canvas by
-        # default instead of expanding it, silently clipping the overflow.
-        fig.savefig(f"{out_path}.png", dpi=300, facecolor=fig.get_facecolor(), bbox_inches="tight")
-        fig.savefig(f"{out_path}.pdf", facecolor=fig.get_facecolor(), bbox_inches="tight")
-
+        _save(fig, out)
     return fig
 
 
+def _save(fig: plt.Figure, out: Union[str, Path]) -> None:
+    # `out` is a path *stem* (no extension) -- append, don't use with_suffix():
+    # with_suffix() replaces everything after the LAST dot in the stem, which
+    # mangles any stem containing a dot (e.g. a model name like "gpt-5.3-codex").
+    out_path = Path(out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # bbox_inches="tight": a long `label` (e.g. a full judge_id) can make the
+    # title wider than the figure canvas; savefig crops to the canvas by
+    # default instead of expanding it, silently clipping the overflow.
+    fig.savefig(f"{out_path}.png", dpi=300, facecolor=fig.get_facecolor(), bbox_inches="tight")
+    fig.savefig(f"{out_path}.pdf", facecolor=fig.get_facecolor(), bbox_inches="tight")
+
+
+def _discrete_bin_edges_test() -> None:
+    """Regression test: near-continuous data (many distinct values close together)
+    must fall back to a regular grid, not one bin per value (which renders as a
+    solid smear -- this happened for real with a hash-based 'random' judge whose
+    72 items are all slightly different floats)."""
+    rng = np.random.default_rng(0)
+    near_continuous = rng.uniform(0, 1, size=72)
+    edges = _discrete_bin_edges(near_continuous)
+    assert len(edges) - 1 <= 25, f"expected a capped bin count, got {len(edges) - 1} bins"
+
+    discrete = np.array([0.25, 0.35, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0])
+    edges_d = _discrete_bin_edges(discrete)
+    assert len(edges_d) - 1 == len(discrete), f"expected one bin per unique value, got {len(edges_d) - 1}"
+    print("_discrete_bin_edges_test passed")
+
+
 def plot_validity_stability_scatter_test() -> None:
-    """Headless smoke test: builds a figure from synthetic data on the Agg backend."""
+    """Headless smoke test: builds a full joint-plot figure from synthetic data."""
     import matplotlib
 
     matplotlib.use("Agg")
@@ -161,10 +306,29 @@ def plot_validity_stability_scatter_test() -> None:
     repeats = {i: [v, v + rng.normal(0, 0.02), v + rng.normal(0, 0.02)] for i, v in enumerate(proxy)}
     fig = plot_validity_stability_scatter(proxy, target, repeats, label="synthetic demo")
     assert fig is not None
+    assert len(fig.axes) == 4  # central + top marginal + right marginal + info
     plt.close(fig)
     print("plot_validity_stability_scatter_test passed")
 
 
+def plot_validity_stability_scatter_ax_mode_test() -> None:
+    """ax= composition still works (simplified single-panel path)."""
+    import matplotlib
+
+    matplotlib.use("Agg")
+    rng = np.random.default_rng(1)
+    target = rng.uniform(0, 1, size=30)
+    proxy = np.clip(target + rng.normal(0, 0.1, size=30), 0, 1)
+    fig, ax = plt.subplots()
+    result_fig = plot_validity_stability_scatter(proxy, target, std=0.05, ax=ax)
+    assert result_fig is fig
+    assert len(fig.axes) == 1
+    plt.close(fig)
+    print("plot_validity_stability_scatter_ax_mode_test passed")
+
+
 if __name__ == "__main__":
+    _discrete_bin_edges_test()
     plot_validity_stability_scatter_test()
+    plot_validity_stability_scatter_ax_mode_test()
     print("Done, success! \a")

--- a/py_src/uutils/stats_uu/validity_stability.py
+++ b/py_src/uutils/stats_uu/validity_stability.py
@@ -49,7 +49,7 @@ from typing import Mapping, Optional, Sequence, Tuple
 import numpy as np
 
 try:
-    from scipy.stats import spearmanr, pearsonr
+    from scipy.stats import spearmanr, pearsonr, kendalltau, wasserstein_distance
 
     _HAVE_SCIPY = True
 except ImportError:  # pragma: no cover - scipy is a declared dependency
@@ -199,6 +199,73 @@ def compute_validity_stability(
     )
 
 
+def bootstrap_correlation_ci(
+    d1: Sequence[float],
+    d2: Sequence[float],
+    *,
+    corr_method: str = "spearman",
+    n_boot: int = 2000,
+    seed: int = 0,
+) -> Tuple[float, float]:
+    """
+    95% CI on Corr(d1, d2) (unclipped, i.e. on validity_raw) via the item-level
+    nonparametric bootstrap: resample items with replacement, recompute the
+    correlation, take the 2.5/97.5 percentiles. Mirrors the resampling
+    convention already used elsewhere in this codebase (e.g.
+    experiments/04_veribench_validation/correlation_analysis.py's
+    `_bootstrap_ci`) rather than a different bootstrap scheme.
+    """
+    x = np.asarray(d1, dtype=float)
+    y = np.asarray(d2, dtype=float)
+    if x.shape != y.shape or x.shape[0] < 3:
+        return float("nan"), float("nan")
+    stat_fn = spearmanr if corr_method == "spearman" else pearsonr
+    rng = np.random.default_rng(seed)
+    n = x.shape[0]
+    vals = []
+    for _ in range(n_boot):
+        idx = rng.integers(0, n, n)
+        r = float(stat_fn(x[idx], y[idx]).statistic)
+        if np.isfinite(r):
+            vals.append(r)
+    if not vals:
+        return float("nan"), float("nan")
+    lo, hi = np.percentile(vals, [2.5, 97.5])
+    return float(lo), float(hi)
+
+
+def compute_kendall_tau_b(d1: Sequence[float], d2: Sequence[float]) -> float:
+    """
+    Kendall's tau-b: like Spearman, a rank correlation, but corrects for tied
+    ranks rather than assigning fractional midranks -- the more defensible
+    choice when the data is a tie-heavy lattice (e.g. human labels averaged
+    from a handful of integer ratings). Reported alongside validity (which
+    uses Spearman) as a secondary diagnostic, not a replacement for it.
+    """
+    x = np.asarray(d1, dtype=float)
+    y = np.asarray(d2, dtype=float)
+    if not _HAVE_SCIPY:
+        raise ImportError("scipy is required for compute_kendall_tau_b")
+    tau = float(kendalltau(x, y, variant="b").statistic)
+    return tau if np.isfinite(tau) else 0.0
+
+
+def compute_calibration_gap(d1: Sequence[float], d2: Sequence[float]) -> float:
+    """
+    1D Wasserstein (earth-mover's) distance between the marginal distributions
+    of d1 and d2 -- how far apart the two signals' *levels* are, independent
+    of whether they're paired or how well they correlate. This is a distinct
+    quantity from validity: a proxy can be perfectly rank-correlated with a
+    target while sitting on a totally different part of the scale (e.g. a
+    judge that is uniformly harsher than a human rater), and validity
+    (correlation-based) is invariant to exactly that offset by construction.
+    Report calibration gap as a separate diagnostic, never folded into VS.
+    """
+    if not _HAVE_SCIPY:
+        raise ImportError("scipy is required for compute_calibration_gap")
+    return float(wasserstein_distance(np.asarray(d1, dtype=float), np.asarray(d2, dtype=float)))
+
+
 def compute_validity_test() -> None:
     """M^C alone: perfectly correlated -> validity == 1.0, no stability term needed."""
     d1 = [0.1, 0.4, 0.6, 0.9, 0.2, 0.7]
@@ -250,10 +317,41 @@ def compute_vs_score_missing_stability_raises_test() -> None:
         print("compute_vs_score_missing_stability_raises_test passed")
 
 
+def bootstrap_correlation_ci_test() -> None:
+    """CI should bracket the point estimate and shrink toward it as n grows."""
+    rng = np.random.default_rng(0)
+    d1 = rng.uniform(0, 1, size=60)
+    d2 = np.clip(d1 + rng.normal(0, 0.1, size=60), 0, 1)
+    point = compute_validity(d1, d2).validity_raw
+    lo, hi = bootstrap_correlation_ci(d1, d2, n_boot=500, seed=0)
+    assert lo <= point <= hi, f"{lo=}, {point=}, {hi=}"
+    print(f"bootstrap_correlation_ci_test passed: point={point:.3f}, CI=[{lo:.3f}, {hi:.3f}]")
+
+
+def compute_kendall_tau_b_test() -> None:
+    d1 = [1, 2, 3, 4, 5]
+    d2 = [1, 2, 3, 4, 5]
+    assert abs(compute_kendall_tau_b(d1, d2) - 1.0) < 1e-9
+    d2_rev = [5, 4, 3, 2, 1]
+    assert abs(compute_kendall_tau_b(d1, d2_rev) - (-1.0)) < 1e-9
+    print("compute_kendall_tau_b_test passed")
+
+
+def compute_calibration_gap_test() -> None:
+    same = [0.1, 0.2, 0.3, 0.4]
+    assert compute_calibration_gap(same, same) == 0.0
+    shifted = [v + 0.5 for v in same]
+    assert abs(compute_calibration_gap(same, shifted) - 0.5) < 1e-9
+    print("compute_calibration_gap_test passed")
+
+
 if __name__ == "__main__":
     compute_validity_test()
     compute_validity_matches_validity_stability_test()
     compute_vs_score_test()
     compute_vs_score_explicit_std_test()
     compute_vs_score_missing_stability_raises_test()
+    bootstrap_correlation_ci_test()
+    compute_kendall_tau_b_test()
+    compute_calibration_gap_test()
     print("Done, success! \a")

--- a/py_src/uutils/stats_uu/validity_stability.py
+++ b/py_src/uutils/stats_uu/validity_stability.py
@@ -1,0 +1,259 @@
+"""
+Validity-Stability score (VS): a single-number summary of "how much should I
+trust a cheap proxy signal as a stand-in for an expensive target signal?"
+
+Two operators on a pair of paired vectors (D1, D2), D1 the proxy side:
+
+    M^C(D1, D2)  = clip_[0,1](Corr(D1, D2))                      -- validity alone
+    M^VS(D1, D2) = ( M^C(D1, D2) * (1 - STD(D1)) )^0.5            -- validity + stability
+
+Two textbook psychometric ingredients, combined by geometric mean so either
+one being ~0 collapses the score to ~0 (a soft AND, not an average):
+    - validity:  does the proxy track the target?    Corr(D1, D2), items
+      paired 1:1 (same index set on both sides).
+    - stability: is the proxy internally consistent?  1 - STD(D1), where STD
+      comes from REPEATED measurements of the proxy (D1) on the same item --
+      NOT the spread of the proxy's scores across different items. A proxy
+      that outputs the same score for every item regardless of quality is
+      uninformative, and must not be *rewarded* by (1 - STD) being large, so
+      STD has to come from repeats (or an explicit instability figure you
+      already trust), never from across-item spread.
+
+Use `compute_validity` (M^C) alone whenever a stability factor must NOT be
+present -- e.g. a property estimator that correlates a proxy against a
+constructed ground truth (a bug-ladder rung, a spec-removal rung) rather than
+a repeated-measurement target. Instantiating M^VS on *both* sides of a bridge
+correlation would put the same (1 - STD) factor into both scalars, making
+part of that correlation mechanical rather than evidential -- a
+high-variance proxy would score low on both axes regardless of what the
+correlation itself does. Rule of thumb: the criterion/target side gets M^VS;
+anything correlated against a constructed (non-repeated-measurement) ground
+truth gets M^C only.
+
+This originates from certifying LLM judges of formal proofs, where the proxy
+is a judge's score and the target is a human rating (cert-judge's TI_2' =
+M^VS(judge, human); see that repo's ti2prime_plot.py) -- but both operators
+are generic: any time you have (a) a cheap/automatic signal paired with an
+expensive/gold signal on the same items, this applies, and M^VS further
+applies whenever you also have (b) repeated measurements of the cheap
+signal. M^VS is effectively a drop-in replacement for reporting a bare
+correlation coefficient whenever the cheap signal's own repeat-noise matters
+to whether you'd trust it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+try:
+    from scipy.stats import spearmanr, pearsonr
+
+    _HAVE_SCIPY = True
+except ImportError:  # pragma: no cover - scipy is a declared dependency
+    _HAVE_SCIPY = False
+
+
+def _clip01(x: float) -> float:
+    return float(max(0.0, min(1.0, x)))
+
+
+def _compute_clipped_corr(
+    d1: Sequence[float], d2: Sequence[float], corr_method: str
+) -> Tuple[float, float, int]:
+    """Shared by compute_validity and compute_validity_stability. Returns (validity, validity_raw, n)."""
+    x = np.asarray(d1, dtype=float)
+    y = np.asarray(d2, dtype=float)
+    if x.shape != y.shape:
+        raise ValueError(f"d1 and d2 must be paired 1:1, got shapes {x.shape} vs {y.shape}")
+    n = x.shape[0]
+    if n < 3:
+        raise ValueError(f"need >= 3 paired items to compute a correlation, got {n}")
+    if corr_method not in ("spearman", "pearson"):
+        raise ValueError(f"unknown corr_method {corr_method!r}, expected 'spearman' or 'pearson'")
+    if not _HAVE_SCIPY:
+        raise ImportError("scipy is required to compute a correlation")
+    stat_fn = spearmanr if corr_method == "spearman" else pearsonr
+    validity_raw = float(stat_fn(x, y).statistic)
+    if not np.isfinite(validity_raw):
+        validity_raw = 0.0
+    return _clip01(validity_raw), validity_raw, n
+
+
+@dataclass
+class ValidityResult:
+    """M^C(D1, D2): clip_[0,1](Corr(D1, D2)) alone -- no stability term.
+
+    For measurements that must not include a stability factor -- see this
+    module's docstring, "M^VS on both sides of a bridge" -- e.g. a property
+    estimator correlating a proxy against a constructed ground truth (a
+    ladder rung) rather than a repeated-measurement target.
+    """
+
+    validity: float
+    validity_raw: float  # unclipped signed correlation, kept for diagnostics
+    n_items: int
+    corr_method: str
+
+    def formula_str(self, symbol: str = "M^C") -> str:
+        """Mathtext-ish legend label, e.g. M^C = 0.48."""
+        return rf"${symbol} = {self.validity:.3f}$"
+
+
+def compute_validity(
+    d1: Sequence[float],
+    d2: Sequence[float],
+    *,
+    corr_method: str = "spearman",
+) -> ValidityResult:
+    """M^C(d1, d2) = clip_[0,1](Corr(d1, d2)). Stability-free -- see ValidityResult docstring."""
+    validity, validity_raw, n = _compute_clipped_corr(d1, d2, corr_method)
+    return ValidityResult(validity=validity, validity_raw=validity_raw, n_items=n, corr_method=corr_method)
+
+
+@dataclass
+class ValidityStabilityResult:
+    """M^VS(proxy, target) and the two ingredients it was built from."""
+
+    vs_score: float
+    validity: float  # clip_[0,1](Corr(proxy, target)) -- the value actually used
+    validity_raw: float  # unclipped signed correlation, kept for diagnostics
+    stability: float  # 1 - STD -- the value actually used (higher = more stable)
+    n_items: int
+    corr_method: str
+    stability_source: str  # "repeat_scores" | "explicit"
+
+    def formula_str(self, symbol: str = "VS") -> str:
+        """Mathtext legend label, e.g. VS = (0.48 x (1-0.07))^0.5 = 0.667."""
+        std_shown = 1.0 - self.stability
+        return (
+            rf"${symbol} = ({self.validity:.2f} \times (1-{std_shown:.2f}))^{{0.5}}"
+            rf" = {self.vs_score:.3f}$"
+        )
+
+
+def compute_validity_stability(
+    proxy_scores: Sequence[float],
+    target_scores: Sequence[float],
+    repeat_scores_by_item: Optional[Mapping[object, Sequence[float]]] = None,
+    *,
+    std: Optional[float] = None,
+    corr_method: str = "spearman",
+) -> ValidityStabilityResult:
+    """
+    VS = M^VS(proxy_scores, target_scores)
+       = ( clip_[0,1](Corr(proxy_scores, target_scores)) * (1 - STD) )^0.5.
+
+    `proxy_scores`/`target_scores` are paired per item (same order, same
+    length), both in [0,1]; `Corr` is computed over those items.
+
+    The stability term must be supplied explicitly -- there is no default,
+    because guessing wrong silently reverses the sign of what gets rewarded
+    (see module docstring):
+      - `repeat_scores_by_item`: item -> that item's raw repeated proxy
+        measurements; STD is the pooled repeat std,
+        sqrt(mean_i(var(repeat_scores_i))).
+      - `std`: a precomputed instability figure, used as-is.
+
+    If you don't have (or don't want) a stability term, use `compute_validity`
+    (M^C) instead -- do not fake this one with a made-up std.
+    """
+    validity, validity_raw, n = _compute_clipped_corr(proxy_scores, target_scores, corr_method)
+
+    if std is not None:
+        std_val = float(std)
+        stability_source = "explicit"
+    elif repeat_scores_by_item is not None:
+        item_vars = [
+            float(np.var(np.asarray(v, dtype=float)))
+            for v in repeat_scores_by_item.values()
+            if len(v) > 1
+        ]
+        if not item_vars:
+            raise ValueError(
+                "repeat_scores_by_item had no item with >= 2 repeats to estimate stability"
+            )
+        std_val = float(np.sqrt(np.mean(item_vars)))
+        stability_source = "repeat_scores"
+    else:
+        raise ValueError(
+            "compute_validity_stability needs a stability term: pass `std` (precomputed) "
+            "or `repeat_scores_by_item` (raw per-item repeat measurements). Falling back to "
+            "the across-item std of proxy_scores would reward a proxy that never varies its "
+            "score regardless of item quality -- see module docstring."
+        )
+    std_val = _clip01(std_val)
+    stability = 1.0 - std_val
+
+    vs_score = float((validity * stability) ** 0.5)
+    return ValidityStabilityResult(
+        vs_score=vs_score,
+        validity=validity,
+        validity_raw=validity_raw,
+        stability=stability,
+        n_items=n,
+        corr_method=corr_method,
+        stability_source=stability_source,
+    )
+
+
+def compute_validity_test() -> None:
+    """M^C alone: perfectly correlated -> validity == 1.0, no stability term needed."""
+    d1 = [0.1, 0.4, 0.6, 0.9, 0.2, 0.7]
+    d2 = [0.0, 0.3, 0.5, 1.0, 0.1, 0.8]
+    result = compute_validity(d1, d2)
+    assert abs(result.validity - 1.0) < 1e-9, f"{result=}"
+    print(f"compute_validity_test passed: {result=}")
+
+
+def compute_validity_matches_validity_stability_test() -> None:
+    """The `validity` component of M^VS equals standalone M^C on the same (d1, d2)."""
+    d1 = [0.1, 0.5, 0.3, 0.9, 0.6, 0.2]
+    d2 = [0.2, 0.4, 0.3, 0.8, 0.5, 0.1]
+    only_validity = compute_validity(d1, d2)
+    with_stability = compute_validity_stability(d1, d2, std=0.1)
+    assert only_validity.validity == with_stability.validity
+    assert only_validity.validity_raw == with_stability.validity_raw
+    print("compute_validity_matches_validity_stability_test passed")
+
+
+def compute_vs_score_test() -> None:
+    """Perfectly stable, perfectly correlated proxy -> VS == 1.0."""
+    proxy = [0.1, 0.4, 0.6, 0.9, 0.2, 0.7]
+    target = [0.0, 0.3, 0.5, 1.0, 0.1, 0.8]
+    repeats = {i: [v, v, v] for i, v in enumerate(proxy)}
+    result = compute_validity_stability(proxy, target, repeats)
+    assert abs(result.vs_score - 1.0) < 1e-9, f"{result=}"
+    assert result.stability_source == "repeat_scores"
+    print(f"compute_vs_score_test passed: {result=}")
+
+
+def compute_vs_score_explicit_std_test() -> None:
+    """`std=` path matches the `repeat_scores_by_item=` path for equivalent inputs."""
+    proxy = [0.2, 0.5, 0.8, 0.3, 0.6]
+    target = [0.1, 0.6, 0.7, 0.2, 0.9]
+    via_std = compute_validity_stability(proxy, target, std=0.05)
+    assert via_std.stability_source == "explicit"
+    assert abs(via_std.stability - 0.95) < 1e-9
+    print(f"compute_vs_score_explicit_std_test passed: {via_std=}")
+
+
+def compute_vs_score_missing_stability_raises_test() -> None:
+    proxy = [0.2, 0.5, 0.8, 0.3, 0.6]
+    target = [0.1, 0.6, 0.7, 0.2, 0.9]
+    try:
+        compute_validity_stability(proxy, target)
+        raise AssertionError("expected ValueError when no stability term is given")
+    except ValueError:
+        print("compute_vs_score_missing_stability_raises_test passed")
+
+
+if __name__ == "__main__":
+    compute_validity_test()
+    compute_validity_matches_validity_stability_test()
+    compute_vs_score_test()
+    compute_vs_score_explicit_std_test()
+    compute_vs_score_missing_stability_raises_test()
+    print("Done, success! \a")


### PR DESCRIPTION
## Summary
- `M^C(D1, D2) = clip_[0,1](Corr(D1, D2))` — validity alone, stability-free.
- `M^VS(D1, D2) = (M^C(D1, D2) * (1 - STD(D1)))^0.5` — validity + stability.
- `plot_validity_stability_scatter`: item-level joint plot — central panel with count-sized markers (tie-aware) and per-position repeat-std error bars, discrete-aware (tie-snapped) marginal histograms on top/right, and an info panel with the formula, a bootstrap 95% CI on the correlation, Kendall tau-b, and an optional calibration-gap (Wasserstein) diagnostic.
- `compute_validity` (`M^C` alone), for contexts where a stability factor must *not* appear on both sides of a correlation.

First consumer: brando90/cert-judge#38 (`TI_2' = M^VS(judge_scores, human_scores)`).

## Design history (2 commits)
1. First pass: single-panel scatter + 2D Gaussian KDE density wash + y=x reference line.
2. Revision after the first version was reviewed on real data: a 2D KDE is the wrong estimator once data is tie-heavy at small n (e.g. n=72 over ~9 distinct values) — it can make a perfectly-aligned proxy and a shuffled one look visually similar, since shuffling preserves both marginals while sending the correlation to zero. Replaced with marginal histograms (with a regular-grid fallback past 25 distinct values, since one-bin-per-value degenerates into unreadable slivers on near-continuous data — found this on a hash-based proxy) + count-sized central markers + error bars. `y=x` now off by default (`show_diagonal=False`): proxy/target are frequently on uncalibrated scales, and `M^VS` is level-invariant by construction. Added `bootstrap_correlation_ci`, `compute_kendall_tau_b`, `compute_calibration_gap`.

## Test plan
- [x] `python3 py_src/uutils/stats_uu/validity_stability.py` — 8/8 inline tests pass
- [x] `python3 py_src/uutils/plot/validity_stability_scatter.py` — 3/3 inline tests pass (incl. a regression test for the bin-degeneracy bug)
- [x] Exercised via cert-judge on real data (3 judge configs), cross-checked against already-audited correlations, exact match
- [x] Independent adversarial review pass (fresh-eyes fork): formula orientation, edge cases (pearson, `ax=` composition, boundary n_items, constant-score/degenerate KDE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qa3Pfv37ycBQBot7JJaDa4